### PR TITLE
sp1: use compressed proofs

### DIFF
--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -57,9 +57,11 @@ impl ProverType {
         input: &SP1Stdin,
     ) -> Result<SP1ProofWithPublicValues, SP1Error> {
         match self {
-            ProverType::Cpu(cpu_prover) => cpu_prover.prove(pk, input).core().run(),
-            ProverType::Gpu(cuda_prover) => cuda_prover.prove(pk, input).core().run(),
-            ProverType::Network(network_prover) => network_prover.prove(pk, input).core().run(),
+            ProverType::Cpu(cpu_prover) => cpu_prover.prove(pk, input).compressed().run(),
+            ProverType::Gpu(cuda_prover) => cuda_prover.prove(pk, input).compressed().run(),
+            ProverType::Network(network_prover) => {
+                network_prover.prove(pk, input).compressed().run()
+            }
         }
         .map_err(|e| SP1Error::Prove(ProveError::Client(e.into())))
     }


### PR DESCRIPTION
This PR switches SP1 from [Core proof type](https://docs.succinct.xyz/docs/sp1/generating-proofs/proof-types#core-default) to[ Compressed proof type](https://docs.succinct.xyz/docs/sp1/generating-proofs/proof-types#compressed).

I wouldn't think of generalizing the API to support multiple options until we incorporate Hypercube since might be wasted effort. I think using compressed proofs is a fair choice today.