### PR TITLE
Add automatic name and sdk version

### DIFF
--- a/.github/workflows/check_pico_image.yml
+++ b/.github/workflows/check_pico_image.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build_pico_image:
+    if: ${{ false }} # See issue #49
     name: Build Pico Docker Image
     runs-on: ubuntu-latest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,164 +71,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-consensus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "alloy-serde",
- "alloy-trie",
- "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "k256",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_with",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
-name = "alloy-eip2124"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
-dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "crc",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-eip2930"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
-dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "serde",
-]
-
-[[package]]
-name = "alloy-eip7702"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
-dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-eips"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
-dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "alloy-serde",
- "auto_impl",
- "c-kzg",
- "derive_more 2.0.1",
- "either",
- "serde",
- "sha2",
-]
-
-[[package]]
-name = "alloy-json-abi"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
-dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-json-rpc"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
-dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-sol-types 1.1.0",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "alloy-network"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
- "alloy-primitives 1.1.0",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
- "alloy-sol-types 1.1.0",
- "async-trait",
- "auto_impl",
- "derive_more 2.0.1",
- "futures-utils-wasm",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives 1.1.0",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,24 +98,18 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
 dependencies = [
- "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 2.0.1",
- "foldhash",
  "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "itoa",
  "k256",
- "keccak-asm",
  "paste",
- "proptest",
  "rand 0.9.1",
  "ruint",
- "rustc-hash 2.1.1",
  "serde",
- "sha3",
  "tiny-keccak",
 ]
 
@@ -283,93 +119,8 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
 dependencies = [
- "alloy-rlp-derive",
  "arrayvec",
  "bytes",
-]
-
-[[package]]
-name = "alloy-rlp-derive"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "alloy-rpc-types-any"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
-dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types 1.1.0",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
-dependencies = [
- "alloy-primitives 1.1.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-signer"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
-dependencies = [
- "alloy-primitives 1.1.0",
- "async-trait",
- "auto_impl",
- "either",
- "elliptic-curve",
- "k256",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "alloy-signer-local"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives 1.1.0",
- "alloy-signer",
- "async-trait",
- "k256",
- "rand 0.8.5",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -378,23 +129,9 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
 dependencies = [
- "alloy-sol-macro-expander 0.7.7",
- "alloy-sol-macro-input 0.7.7",
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3ef8e0d622453d969ba3cded54cf6800efdc85cb929fe22c5bdf8335666757"
-dependencies = [
- "alloy-sol-macro-expander 1.1.0",
- "alloy-sol-macro-input 1.1.0",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -406,7 +143,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
 dependencies = [
- "alloy-sol-macro-input 0.7.7",
+ "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.9.0",
@@ -414,25 +151,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "syn-solidity 0.7.7",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e84bd0693c69a8fbe3ec0008465e029c6293494df7cb07580bf4a33eff52e1"
-dependencies = [
- "alloy-sol-macro-input 1.1.0",
- "const-hex",
- "heck 0.5.0",
- "indexmap 2.9.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
- "syn-solidity 1.1.0",
+ "syn-solidity",
  "tiny-keccak",
 ]
 
@@ -448,33 +167,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "syn-solidity 0.7.7",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3de663412dadf9b64f4f92f507f78deebcc92339d12cf15f88ded65d41c7935"
-dependencies = [
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
- "syn-solidity 1.1.0",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
-dependencies = [
- "serde",
- "winnow 0.7.10",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -484,38 +177,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
  "alloy-primitives 0.7.7",
- "alloy-sol-macro 0.7.7",
+ "alloy-sol-macro",
  "const-hex",
  "serde",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives 1.1.0",
- "alloy-sol-macro 1.1.0",
- "const-hex",
- "serde",
-]
-
-[[package]]
-name = "alloy-trie"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
-dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-rlp",
- "arrayvec",
- "derive_more 2.0.1",
- "nybbles",
- "serde",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
@@ -997,9 +661,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "async-stream"
@@ -1329,18 +990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blst"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
-dependencies = [
- "cc",
- "glob",
- "threadpool",
- "zeroize",
-]
-
-[[package]]
 name = "bon"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1051,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-utils"
+version = "0.1.0"
+dependencies = [
+ "cargo_metadata 0.20.0",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,21 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c-kzg"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
-dependencies = [
- "blst",
- "cc",
- "glob",
- "hex",
- "libc",
- "once_cell",
- "serde",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,13 +1123,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver 1.0.26",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -1502,7 +1168,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+dependencies = [
+ "camino",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -1777,21 +1458,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -2409,9 +2075,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "elf"
@@ -2570,6 +2233,7 @@ name = "ere-jolt"
 version = "0.1.0"
 dependencies = [
  "ark-serialize 0.5.0",
+ "build-utils",
  "jolt",
  "jolt-core",
  "jolt-sdk",
@@ -2582,6 +2246,7 @@ dependencies = [
 name = "ere-openvm"
 version = "0.1.0"
 dependencies = [
+ "build-utils",
  "openvm-build",
  "openvm-circuit",
  "openvm-sdk",
@@ -2596,6 +2261,7 @@ name = "ere-pico"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "build-utils",
  "pico-sdk",
  "thiserror 2.0.12",
  "zkvm-interface",
@@ -2607,6 +2273,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "build-utils",
  "hex",
  "risc0-zkvm",
  "serde_json",
@@ -2621,6 +2288,7 @@ name = "ere-sp1"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "build-utils",
  "sp1-sdk",
  "tempfile",
  "thiserror 2.0.12",
@@ -2635,6 +2303,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "blake3",
+ "build-utils",
  "serde",
  "tempfile",
  "thiserror 2.0.12",
@@ -2947,12 +2616,6 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
-
-[[package]]
-name = "futures-utils-wasm"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "gcd"
@@ -3917,7 +3580,7 @@ version = "0.1.0"
 source = "git+https://github.com/kevaundray/jolt?branch=kw%2Fere-fork#831dd937303b1055f995d3836d0dd61a818969fe"
 dependencies = [
  "alloy-primitives 0.7.7",
- "alloy-sol-types 0.7.7",
+ "alloy-sol-types",
  "anyhow",
  "ark-bn254",
  "ark-ec",
@@ -4178,17 +3841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "malachite"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,7 +4051,7 @@ dependencies = [
  "indexmap 2.9.0",
  "metrics",
  "num_cpus",
- "ordered-float",
+ "ordered-float 4.6.0",
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
@@ -4713,19 +4365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad2e855e8019f99e4b94ac33670eb4e4f570a2e044f3749a0b2c7f83b841e52c"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "nybbles"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
-dependencies = [
- "alloy-rlp",
- "const-hex",
- "proptest",
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -5684,6 +5323,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -5729,12 +5377,12 @@ dependencies = [
 
 [[package]]
 name = "p3-air"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3079235eaa131553ae7ff992317ebeb1d431d238896315672869570ef0c38d"
+checksum = "d05a97452c4b1cfa8626e69181d901fc8231d99ff7d87e9701a2e6b934606615"
 dependencies = [
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
 ]
 
 [[package]]
@@ -5767,15 +5415,15 @@ dependencies = [
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecc3edc6fb8186268e05031c26a8b2b1e567957d63adcae1026d55d6bb189b"
+checksum = "7521838ecab2ddf4f7bc4ceebad06ec02414729598485c1ada516c39900820e8"
 dependencies = [
  "num-bigint 0.4.6",
- "p3-field 0.2.2-succinct",
- "p3-mds 0.2.2-succinct",
- "p3-poseidon2 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-mds 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -5832,15 +5480,15 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e3df8d85259448803639657a4aafdf4caad9422f9be6264187f179fa0bc761"
+checksum = "c0dd4d095d254783098bd09fc5fdf33fd781a1be54608ab93cb3ed4bd723da54"
 dependencies = [
  "ff 0.13.1",
  "num-bigint 0.4.6",
- "p3-field 0.2.2-succinct",
- "p3-poseidon2 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -5871,14 +5519,14 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11466fe23e14dd6d61512c8ce5a068de87e3d92954058b05b24ae12b7824a960"
+checksum = "c5d18c223b7e0177f4ac91070fa3f6cc557d5ee3b279869924c3102fb1b20910"
 dependencies = [
- "p3-field 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "serde",
  "tracing",
 ]
@@ -5931,15 +5579,15 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30877bdc426bfa5ebb0033dbc45ba1b083dfeb0db7ad7628c72a5be7562324ce"
+checksum = "b38fe979d53d4f1d64158c40b3cd9ea1bd6b7bc8f085e489165c542ef914ae28"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "serde",
 ]
 
@@ -5971,14 +5619,14 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eece7b035978976138622b116fefe6c4cc372b1ce70739c40e7a351a9bb68f1f"
+checksum = "46414daedd796f1eefcdc1811c0484e4bced5729486b6eaba9521c572c76761a"
 dependencies = [
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "tracing",
 ]
 
@@ -6018,14 +5666,14 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f0edf3fde4fd0d1455e901fc871c558010ae18db6e68f1b0fa111391855316"
+checksum = "48948a0516b349e9d1cdb95e7236a6ee010c44e68c5cc78b4b92bf1c4022a0d9"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.2.2-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -6070,19 +5718,19 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07df36a633712e2a73387674a7e1922f3e58bc28b4e55359b2d3749e146f8faa"
+checksum = "a0c274dab2dcd060cdea9ab3f8f7129f5fa5f08917d6092dc2b297a31d883aa0"
 dependencies = [
  "itertools 0.12.1",
- "p3-challenger 0.2.2-succinct",
- "p3-commit 0.2.2-succinct",
- "p3-dft 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-interpolation 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-interpolation 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "serde",
  "tracing",
 ]
@@ -6144,13 +5792,13 @@ dependencies = [
 
 [[package]]
 name = "p3-interpolation"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09b01809167d6e39e8a34779eb2d5fca50d0ff7b2d13661953b46dc74bf1619"
+checksum = "ed8de7333abb0ad0a17bb78726a43749cc7fcab4763f296894e8b2933841d4d8"
 dependencies = [
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
 ]
 
 [[package]]
@@ -6206,15 +5854,15 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f6bacf49ba7c1d9c436994ace80a96c3532462c655e4339919d5b397035e56"
+checksum = "01c7ec21317c455d39588428e4ec85b96d663ff171ddf102a10e2ca54c942dea"
 dependencies = [
- "p3-air 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-air 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "tracing",
 ]
 
@@ -6278,14 +5926,14 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60961b4d7ffd2e8412ce4e66e213de610356df71cc4e396519c856a664138a27"
+checksum = "3e4de3f373589477cb735ea58e125898ed20935e03664b4614c7fac258b3c42f"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
  "serde",
  "tracing",
@@ -6309,9 +5957,9 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbe762738c382c9483410f52348ab9de41bb42c391e8171643a71486cf1ef8f"
+checksum = "c3968ad1160310296eb04f91a5f4edfa38fe1d6b2b8cd6b5c64e6f9b7370979e"
 dependencies = [
  "rayon",
 ]
@@ -6346,16 +5994,16 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4127956cc6c783b7d021c5c42d5d89456d5f3bda4a7b165fcc2a3fd4e78fbede"
+checksum = "2356b1ed0add6d5dfbf7a338ce534a6fde827374394a52cec16a0840af6e97c9"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
 ]
 
@@ -6395,17 +6043,17 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7eff1ddec74ee4178b40b2b4630f4bf5a02abf2d9619c8c4f8295e59d02a1"
+checksum = "f159e073afbee02c00d22390bf26ebb9ce03bbcd3e6dcd13c6a7a3811ab39608"
 dependencies = [
  "itertools 0.12.1",
- "p3-commit 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "serde",
  "tracing",
 ]
@@ -6508,14 +6156,14 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be09497da406a98e89dc05c1ce539eeef29541bad61a5b2108a44ffe94dd0b4c"
+checksum = "7da1eec7e1b6900581bedd95e76e1ef4975608dd55be9872c9d257a8a9651c3a"
 dependencies = [
  "gcd",
- "p3-field 0.2.2-succinct",
- "p3-mds 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-mds 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "rand 0.8.5",
  "serde",
 ]
@@ -6558,12 +6206,12 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7d954033f657d48490344ca4b3dbcc054962a0e92831b736666bb2f5e5820b"
+checksum = "edb439bea1d822623b41ff4b51e3309e80d13cadf8b86d16ffd5e6efb9fdc360"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
  "serde",
 ]
 
@@ -6605,19 +6253,19 @@ dependencies = [
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064b3923492d182e768dff8a19a36d7742b0166dbff75455fdc99187d3115dd3"
+checksum = "5a86f29c32bf46fa4acb6547d2065a711e146d4faca388b56d75718c60a0097d"
 dependencies = [
  "itertools 0.12.1",
- "p3-air 0.2.2-succinct",
- "p3-challenger 0.2.2-succinct",
- "p3-commit 0.2.2-succinct",
- "p3-dft 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-air 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "serde",
  "tracing",
 ]
@@ -6640,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.2.2-succinct"
+version = "0.2.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6ce0b6bee23fd54e05306f6752ae80b0b71a91166553ab39d7899801497237"
+checksum = "b6c2c2010678b9332b563eaa38364915b585c1a94b5ca61e2c7541c087ddda5c"
 dependencies = [
  "serde",
 ]
@@ -6789,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "pico-derive"
 version = "0.1.0"
-source = "git+https://github.com/brevis-network/pico?tag=v1.1.3#d67fb4389d7d14d55f8ae6d156f436649b9dab2d"
+source = "git+https://github.com/brevis-network/pico?tag=v1.1.4#ef8229f8d13a9d7778b8a547d2bb5bf77374347e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6799,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "pico-patch-libs"
 version = "1.1.3"
-source = "git+https://github.com/brevis-network/pico?tag=v1.1.3#d67fb4389d7d14d55f8ae6d156f436649b9dab2d"
+source = "git+https://github.com/brevis-network/pico?tag=v1.1.4#ef8229f8d13a9d7778b8a547d2bb5bf77374347e"
 dependencies = [
  "bincode",
  "serde",
@@ -6808,7 +6456,7 @@ dependencies = [
 [[package]]
 name = "pico-sdk"
 version = "1.1.3"
-source = "git+https://github.com/brevis-network/pico?tag=v1.1.3#d67fb4389d7d14d55f8ae6d156f436649b9dab2d"
+source = "git+https://github.com/brevis-network/pico?tag=v1.1.4#ef8229f8d13a9d7778b8a547d2bb5bf77374347e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6834,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "pico-vm"
 version = "1.1.3"
-source = "git+https://github.com/brevis-network/pico?tag=v1.1.3#d67fb4389d7d14d55f8ae6d156f436649b9dab2d"
+source = "git+https://github.com/brevis-network/pico?tag=v1.1.4#ef8229f8d13a9d7778b8a547d2bb5bf77374347e"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -7320,7 +6968,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "serde",
 ]
 
 [[package]]
@@ -7639,9 +7286,9 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fe7599ac55ad77515608ec42a9727001559fe4f579c533cb7c973b54800c05"
+checksum = "62eb7025356a233c1bc267c458a2ce56fcfc89b136d813c8a77be14ef1eaf2b1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7658,9 +7305,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17d6657b1fb615c0482bd4b57aae7850911ed7dbdc8e783df20e93f33209a8f"
+checksum = "714776c8ccf3e206ecf499dab6561259beef6e7a82dfb49ccf5c911c7350dd5e"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -7697,9 +7344,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d339c65b0e011677404bd6bdfe1b0f29748187a568fb2f74df7fb650590181a"
+checksum = "0094af5a57b020388a03bdd3834959c7d62723f1687be81414ade25104d93263"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7719,9 +7366,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25d00769a0f855d4973e8a85dbffe6e13889ca6a4703cf98d0a2976bdc2be17"
+checksum = "43afb4572af3b812fb0c83bfac5014041af10937288dcb67b7f9cea649483ff8"
 dependencies = [
  "cc",
  "cust",
@@ -7735,9 +7382,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6501fd3936aea2dd3e55915f34328fe96e6ca25ef00320242f837ae668785b"
+checksum = "76ebded45c902c2b6939924a1cddd1d06b5d1d4ad1531e8798ebfee78f9c038d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7761,9 +7408,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7f8aee9b6b299fc5c3259a1a6e00a49a17dfd55811e90070840a887b113645"
+checksum = "3a0eda7272f9e18b914f33b85b58e221056dbef1477ceb13351e442a06a44de9"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -7774,9 +7421,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e0a8f0f56106295bb682dbc27093438e163a5f6384a79e877ab895a11d9ae"
+checksum = "15030849f8356f01f23c74b37dbfa4283100b594eb634109993e9e005ef45f64"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -7806,9 +7453,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddac6b8acb1db761872fafa063155d99fe2cc845dc60037cde9ac05466044898"
+checksum = "7d5e586b310d20fab3f141a318704ded77c20ace155af4db1b6594bd60579b90"
 dependencies = [
  "cc",
  "cust",
@@ -7835,9 +7482,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b31cb7b2a46f0cdaf71803ea7e0389af9f5bc1aea2531106f2972b241f26e98"
+checksum = "7cf5d0b673d5fc67a89147c2e9c53134707dcc8137a43d1ef06b4ff68e99b74f"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -7882,9 +7529,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa210a232361fd671b30918469856b64d715f2564956d0a5df97ab6cb116d28b"
+checksum = "a287e9cd6d7b3b38eeb49c62090c46a1935922309fbd997a9143ed8c43c8f3cb"
 dependencies = [
  "anyhow",
  "blake2",
@@ -7914,9 +7561,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1014d2efcb3b359aff878c9aeb6aa949a6d91f091a2ffb5ffd8d928a1ab7f3"
+checksum = "c59aaf1898f2f5d526a79d53dbe6288aeb1ce52a17184b85af84d06dedb1a367"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -7961,9 +7608,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4de2938eaf24892ef927d9cef6e4acb6a19ce01c017cd498533896f633f332"
+checksum = "cae9cb2c2f6cab2dfa395ea6e2576713929040c7fb0c5f4150d13e1119d18686"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -8396,6 +8043,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_arrays"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8620,9 +8288,6 @@ name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "snark-verifier"
@@ -8687,22 +8352,23 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b45dd7a9d3703f82b1f5e8fdd6c5fb8af1e3b4037f1ffc533435717d567a56"
+checksum = "5563b406d74b417ce07c0d7e0d8184b423f3bc3eacd1e98b105691a167f47c8f"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
  "chrono",
  "clap",
  "dirs",
+ "sp1-prover",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1988844b2273313bf1a3861684f7415f68c00d51139475fd3d72f2326fd6d"
+checksum = "291c086ca35f43725b33337a7a33c64418d89033d8d6e5586f82b9de2cf90dcb"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -8715,10 +8381,10 @@ dependencies = [
  "itertools 0.13.0",
  "nohash-hasher",
  "num",
- "p3-baby-bear 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
  "range-set-blaze",
  "rrs-succinct",
@@ -8739,9 +8405,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7911eeaa80da1eb55ce5bf4c9442d3f1cad85e6dae41601b3ce23d45c48a5871"
+checksum = "236d063c38900e8346342af0b352a23d25b9806b624ee30fcae4c0cc7ddbed27"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -8757,17 +8423,17 @@ dependencies = [
  "num",
  "num_cpus",
  "p256",
- "p3-air 0.2.2-succinct",
- "p3-baby-bear 0.2.2-succinct",
- "p3-challenger 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-keccak-air 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-poseidon2 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-uni-stark 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-keccak-air 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-uni-stark 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "pathdiff",
  "rand 0.8.5",
  "rayon",
@@ -8795,9 +8461,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4bab3c90ca3408ac50cbff14d629205a5178fb3623a2e354a416d9d7560fe02"
+checksum = "d2c81ab46ba84d41e471351329a69ac43be7da1aa701ed29c70048c83c0fe28c"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -8812,9 +8478,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a198a00a1700ea0073a7481138abf256e3f38a15892c42721cdbec5d64d0f4e7"
+checksum = "e4d6faecc70f0ca84d0e1259ab2f5eb6d2d351d263c3cd00edf654f8530c0473"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -8824,7 +8490,7 @@ dependencies = [
  "k256",
  "num",
  "p256",
- "p3-field 0.2.2-succinct",
+ "p3-field 0.2.3-succinct",
  "serde",
  "snowbridge-amcl",
  "sp1-primitives",
@@ -8834,9 +8500,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e3a9d2afa63fa83792c223084abf62c2cb3a60188651e9aa567e25e9fd344d"
+checksum = "c25a3bd262f3b0b0ab59d9bc86638ebd895ade9c16526203023c08f926d62732"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -8844,9 +8510,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc282347d405f23fc8a7cfe93c82e772920bf2e0722cf828eaea69ed530e49"
+checksum = "699935774a5131c1a8b371108d0666c0c80c43611045fb77fae43f2f242676d5"
 dependencies = [
  "bincode",
  "blake3",
@@ -8854,19 +8520,19 @@ dependencies = [
  "hex",
  "lazy_static",
  "num-bigint 0.4.6",
- "p3-baby-bear 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-poseidon2 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "serde",
  "sha2",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694e15302f83608c4be7efbf879f0f2b04c2f90129fc8fe9b625299f59e6200"
+checksum = "8f9381b478115137a435d02756dae7f3da01abaa0b1b9db8c0973389bd5bfaa9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8880,14 +8546,14 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "num-bigint 0.4.6",
- "p3-baby-bear 0.2.2-succinct",
- "p3-bn254-fr 0.2.2-succinct",
- "p3-challenger 0.2.2-succinct",
- "p3-commit 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rayon",
  "serde",
  "serde_json",
@@ -8909,25 +8575,25 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d651075d5de59e212f02ae7d6f1155e5fe2af228c0cab92096d4e8359b619"
+checksum = "e56f69b0e112a7fbba23cbef61fb37f6092ba6897425859b30c4cd2786450179"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-traits",
- "p3-air 0.2.2-succinct",
- "p3-baby-bear 0.2.2-succinct",
- "p3-bn254-fr 0.2.2-succinct",
- "p3-challenger 0.2.2-succinct",
- "p3-commit 0.2.2-succinct",
- "p3-dft 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-fri 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-uni-stark 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-uni-stark 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -8944,16 +8610,16 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630ab95063c1cf52668b23cdae8a216f5749604c3b063f5cdec20ef2c60d086"
+checksum = "6101a4c46d55206a5f0d312fd6f663248cbdb49c90f1662138f20472bef31b71"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
- "p3-baby-bear 0.2.2-succinct",
- "p3-bn254-fr 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "serde",
  "sp1-core-machine",
  "sp1-primitives",
@@ -8966,9 +8632,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2edcf518cedb3d0947f14688089812aec56089b45bdfc5dd162ea25ec8902d7"
+checksum = "13fa9644be4e3b9cf0b1f0976b2c3814dbd5b6d6f47dc8662d6a22828f2c3dd7"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -8979,20 +8645,20 @@ dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num_cpus",
- "p3-air 0.2.2-succinct",
- "p3-baby-bear 0.2.2-succinct",
- "p3-bn254-fr 0.2.2-succinct",
- "p3-challenger 0.2.2-succinct",
- "p3-commit 0.2.2-succinct",
- "p3-dft 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-fri 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-merkle-tree 0.2.2-succinct",
- "p3-poseidon2 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-bn254-fr 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-merkle-tree 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "pathdiff",
  "rand 0.8.5",
  "serde",
@@ -9009,9 +8675,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45acfb50730a6271d8546975063df0946ffaa28d2ce0d0041e7905fb90c9c254"
+checksum = "c5e6d5c7e2620d61956e6f75026a88ef2f714dab4abf84e870f13145e6bbec79"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -9019,9 +8685,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e1bc3fc71f6eafaa1dc5fa9b309ecf55075c14a18561540937a1e2e3964670"
+checksum = "d40fc06701180ce02d6079370d00ca74b8d86c84d85909a3684eddc8bfd8c1bf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9030,9 +8696,9 @@ dependencies = [
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
- "p3-baby-bear 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
  "serde",
  "serde_json",
  "sha2",
@@ -9045,14 +8711,11 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "4.2.0"
+version = "5.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dc0553bed3674fe271a65dd9cdd3569670c619fdc3aaac7588cc6fce39e622"
+checksum = "d20372512858547350dc4fcbed57b9c6af3812da10aa9d497f7625b22bd564d2"
 dependencies = [
  "alloy-primitives 1.1.0",
- "alloy-signer",
- "alloy-signer-local",
- "alloy-sol-types 1.1.0",
  "anyhow",
  "async-trait",
  "backoff",
@@ -9066,9 +8729,9 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "k256",
- "p3-baby-bear 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-fri 0.2.2-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
  "prost",
  "reqwest",
  "reqwest-middleware",
@@ -9093,29 +8756,29 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "4.2.0"
+version = "5.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3623ca4fe6bf08b3f4211f63cc59a115f0559913e2846ec4e65ad4a8524de3d"
+checksum = "5a795a0a309949772a6f26480f5d844e9f2fad9ef82e4caef9e7b0cec98daffe"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-air 0.2.2-succinct",
- "p3-baby-bear 0.2.2-succinct",
- "p3-challenger 0.2.2-succinct",
- "p3-commit 0.2.2-succinct",
- "p3-dft 0.2.2-succinct",
- "p3-field 0.2.2-succinct",
- "p3-fri 0.2.2-succinct",
- "p3-matrix 0.2.2-succinct",
- "p3-maybe-rayon 0.2.2-succinct",
- "p3-merkle-tree 0.2.2-succinct",
- "p3-poseidon2 0.2.2-succinct",
- "p3-symmetric 0.2.2-succinct",
- "p3-uni-stark 0.2.2-succinct",
- "p3-util 0.2.2-succinct",
+ "p3-air 0.2.3-succinct",
+ "p3-baby-bear 0.2.3-succinct",
+ "p3-challenger 0.2.3-succinct",
+ "p3-commit 0.2.3-succinct",
+ "p3-dft 0.2.3-succinct",
+ "p3-field 0.2.3-succinct",
+ "p3-fri 0.2.3-succinct",
+ "p3-matrix 0.2.3-succinct",
+ "p3-maybe-rayon 0.2.3-succinct",
+ "p3-merkle-tree 0.2.3-succinct",
+ "p3-poseidon2 0.2.3-succinct",
+ "p3-symmetric 0.2.3-succinct",
+ "p3-uni-stark 0.2.3-succinct",
+ "p3-util 0.2.3-succinct",
  "rayon-scan",
  "serde",
  "sp1-derive",
@@ -9256,18 +8919,6 @@ name = "syn-solidity"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0f0d4760f4c2a0823063b2c70e97aa2ad185f57be195172ccc0e23c4b787c4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9447,15 +9098,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/build-utils",
     # zkVM interface
     "crates/zkvm-interface",
     # zkVMs
@@ -23,6 +24,7 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 # local dependencies
 zkvm-interface = { path = "crates/zkvm-interface" }
+build-utils = { path = "crates/build-utils" }
 
 [patch.crates-io]
 # These patches are only needed by Jolt

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "build-utils"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+cargo_metadata = "0.20.0"
 
 [lints]
 workspace = true

--- a/crates/build-utils/src/lib.rs
+++ b/crates/build-utils/src/lib.rs
@@ -2,19 +2,18 @@ use std::{env, fs, path::Path};
 
 // Generate a Rust source file that contains the name and version of the SDK.
 pub fn gen_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
-    let workspace_dir = env::var("CARGO_WORKSPACE_DIR").unwrap();
-    let lock = fs::read_to_string(Path::new(&workspace_dir).join("Cargo.lock"))
-        .expect("Cargo.lock not found");
+    let meta = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("Failed to get cargo metadata");
 
-    let version = lock
-        .split("[[package]]")
-        .find(|pkg| pkg.contains(&format!("name = \"{sdk_dep_name}\"")))
-        .and_then(|pkg| {
-            pkg.lines()
-                .find(|l| l.trim_start().starts_with("version ="))
-                .and_then(|l| l.split('"').nth(1))
-        })
-        .unwrap_or_else(|| panic!("{sdk_dep_name} not found in Cargo.lock"));
+    let version = meta
+        .packages
+        .iter()
+        .find(|pkg| pkg.name.eq_ignore_ascii_case(sdk_dep_name))
+        .map(|pkg| pkg.version.to_string())
+        .unwrap_or_else(|| {
+            panic!("Dependency {sdk_dep_name} not found in Cargo.toml");
+        });
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("sdk_version.rs");

--- a/crates/build-utils/src/lib.rs
+++ b/crates/build-utils/src/lib.rs
@@ -21,10 +21,10 @@ pub fn detect_and_generate_name_and_sdk_version(name: &str, sdk_dep_name: &str) 
 // Generate a Rust source file that contains the provided name and version of the SDK.
 pub fn gen_name_and_sdk_version(name: &str, version: &str) {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let dest = Path::new(&out_dir).join("sdk_version.rs");
+    let dest = Path::new(&out_dir).join("name_and_sdk_version.rs");
     fs::write(
         &dest,
-        format!("pub const NAME: &str = \"{name}\";\npub const SDK_VERSION: &str = \"{version}\";"),
+        format!("const NAME: &str = \"{name}\";\nconst SDK_VERSION: &str = \"{version}\";"),
     )
     .unwrap();
     println!("cargo:rerun-if-changed=Cargo.lock");

--- a/crates/build-utils/src/lib.rs
+++ b/crates/build-utils/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{env, fs, path::Path};
 
-// Generate a Rust source file that contains the name and version of the SDK.
-pub fn gen_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
+// Detect and generate a Rust source file that contains the name and version of the SDK.
+pub fn detect_and_generate_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
     let meta = cargo_metadata::MetadataCommand::new()
         .exec()
         .expect("Failed to get cargo metadata");
@@ -15,6 +15,11 @@ pub fn gen_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
             panic!("Dependency {sdk_dep_name} not found in Cargo.toml");
         });
 
+    gen_name_and_sdk_version(name, &version);
+}
+
+// Generate a Rust source file that contains the provided name and version of the SDK.
+pub fn gen_name_and_sdk_version(name: &str, version: &str) {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("sdk_version.rs");
     fs::write(
@@ -22,6 +27,5 @@ pub fn gen_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
         format!("pub const NAME: &str = \"{name}\";\npub const SDK_VERSION: &str = \"{version}\";"),
     )
     .unwrap();
-
     println!("cargo:rerun-if-changed=Cargo.lock");
 }

--- a/crates/build-utils/src/lib.rs
+++ b/crates/build-utils/src/lib.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::Path};
+
+// Generate a Rust source file that contains the name and version of the SDK.
+pub fn gen_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
+    let workspace_dir = env::var("CARGO_WORKSPACE_DIR").unwrap();
+    let lock = fs::read_to_string(Path::new(&workspace_dir).join("Cargo.lock"))
+        .expect("Cargo.lock not found");
+
+    let version = lock
+        .split("[[package]]")
+        .find(|pkg| pkg.contains(&format!("name = \"{sdk_dep_name}\"")))
+        .and_then(|pkg| {
+            pkg.lines()
+                .find(|l| l.trim_start().starts_with("version ="))
+                .and_then(|l| l.split('"').nth(1))
+        })
+        .unwrap_or_else(|| panic!("{sdk_dep_name} not found in Cargo.lock"));
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("sdk_version.rs");
+    fs::write(
+        &dest,
+        format!("pub const NAME: &str = \"{name}\";\npub const SDK_VERSION: &str = \"{version}\";"),
+    )
+    .unwrap();
+
+    println!("cargo:rerun-if-changed=Cargo.lock");
+}

--- a/crates/ere-jolt/Cargo.toml
+++ b/crates/ere-jolt/Cargo.toml
@@ -20,5 +20,8 @@ thiserror = "2"
 toml = "0.8"
 ark-serialize = "0.5.0"
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/ere-jolt/build.rs
+++ b/crates/ere-jolt/build.rs
@@ -1,5 +1,5 @@
 use build_utils::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("sp1", "sp1-sdk");
+    detect_and_generate_name_and_sdk_version("jolt", "jolt-sdk");
 }

--- a/crates/ere-jolt/src/lib.rs
+++ b/crates/ere-jolt/src/lib.rs
@@ -11,6 +11,7 @@ use zkvm_interface::{
     zkVMError,
 };
 
+include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
 mod error;
 mod jolt_methods;
 mod utils;
@@ -101,6 +102,14 @@ impl zkVM for EreJolt {
         } else {
             Err(zkVMError::from(JoltError::ProofVerificationFailed))
         }
+    }
+
+    fn name() -> &'static str {
+        NAME
+    }
+
+    fn sdk_version() -> &'static str {
+        SDK_VERSION
     }
 }
 

--- a/crates/ere-openvm/Cargo.toml
+++ b/crates/ere-openvm/Cargo.toml
@@ -16,5 +16,8 @@ openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v
 
 thiserror = "2"
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/ere-openvm/build.rs
+++ b/crates/ere-openvm/build.rs
@@ -1,5 +1,5 @@
 use build_utils::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("sp1", "sp1-sdk");
+    detect_and_generate_name_and_sdk_version("openvm", "openvm-sdk");
 }

--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -18,6 +18,7 @@ use zkvm_interface::{
     zkVM, zkVMError,
 };
 
+include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
 mod error;
 use error::{CompileError, OpenVMError, VerifyError};
 
@@ -162,6 +163,14 @@ impl zkVM for EreOpenVM {
             .map(|_payload| ())
             .map_err(|e| OpenVMError::Verify(VerifyError::Client(e.into())))
             .map_err(zkVMError::from)
+    }
+
+    fn name() -> &'static str {
+        NAME
+    }
+
+    fn sdk_version() -> &'static str {
+        SDK_VERSION
     }
 }
 

--- a/crates/ere-pico/Cargo.toml
+++ b/crates/ere-pico/Cargo.toml
@@ -11,5 +11,8 @@ thiserror = "2"
 pico-sdk = { git = "https://github.com/brevis-network/pico", tag = "v1.1.3" }
 bincode = "1.3.3"
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/ere-pico/Cargo.toml
+++ b/crates/ere-pico/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 zkvm-interface = { workspace = true }
 thiserror = "2"
-pico-sdk = { git = "https://github.com/brevis-network/pico", tag = "v1.1.3" }
+pico-sdk = { git = "https://github.com/brevis-network/pico", tag = "v1.1.4" }
 bincode = "1.3.3"
 
 [build-dependencies]

--- a/crates/ere-pico/build.rs
+++ b/crates/ere-pico/build.rs
@@ -1,5 +1,5 @@
 use build_utils::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("sp1", "sp1-sdk");
+    detect_and_generate_name_and_sdk_version("pico", "pico-sdk");
 }

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -78,10 +78,10 @@ impl zkVM for ErePico {
         }
 
         let start = Instant::now();
-        let num_cycles = client.emulate(stdin);
+        let emulation_result = client.emulate(stdin);
 
         Ok(ProgramExecutionReport {
-            total_num_cycles: num_cycles,
+            total_num_cycles: emulation_result.0,
             execution_duration: start.elapsed(),
             ..Default::default()
         })

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -5,6 +5,7 @@ use zkvm_interface::{
     zkVM, zkVMError,
 };
 
+include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
 mod error;
 use error::PicoError;
 
@@ -125,6 +126,14 @@ impl zkVM for ErePico {
         let client = DefaultProverClient::new(&self.program);
         let _vk = client.riscv_vk();
         todo!("Verification method missing from sdk")
+    }
+
+    fn name() -> &'static str {
+        NAME
+    }
+
+    fn sdk_version() -> &'static str {
+        SDK_VERSION
     }
 }
 

--- a/crates/ere-risczero/Cargo.toml
+++ b/crates/ere-risczero/Cargo.toml
@@ -17,6 +17,9 @@ tempfile = "3.3"
 serde_json = "1.0"
 thiserror = "2"
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [features]
 metal = ["risc0-zkvm/metal"]
 cuda = ["risc0-zkvm/cuda"]

--- a/crates/ere-risczero/Cargo.toml
+++ b/crates/ere-risczero/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 zkvm-interface = { workspace = true }
 anyhow = "1.0"                                               #TODO: remove only needed in tests
 toml = "0.8"
-risc0-zkvm = { version = "^2.1.0", features = ["unstable"] }
+risc0-zkvm = { version = "^2.2.0", features = ["unstable"] }
 borsh = "1.5.7"
 hex = "*"
 

--- a/crates/ere-risczero/build.rs
+++ b/crates/ere-risczero/build.rs
@@ -1,5 +1,5 @@
 use build_utils::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("risc0", "risc0-sdk");
+    detect_and_generate_name_and_sdk_version("risc0", "risc0-zkvm");
 }

--- a/crates/ere-risczero/build.rs
+++ b/crates/ere-risczero/build.rs
@@ -1,5 +1,5 @@
 use build_utils::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("sp1", "sp1-sdk");
+    detect_and_generate_name_and_sdk_version("risc0", "risc0-sdk");
 }

--- a/crates/ere-risczero/src/lib.rs
+++ b/crates/ere-risczero/src/lib.rs
@@ -7,6 +7,8 @@ use zkvm_interface::{
     zkVM, zkVMError,
 };
 
+include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
+
 mod compile;
 pub use compile::Risc0Program;
 
@@ -120,6 +122,14 @@ impl zkVM for EreRisc0 {
         decoded
             .verify(self.program.image_id)
             .map_err(|err| zkVMError::Other(Box::new(err)))
+    }
+
+    fn name() -> &'static str {
+        NAME
+    }
+
+    fn sdk_version() -> &'static str {
+        SDK_VERSION
     }
 }
 

--- a/crates/ere-sp1/Cargo.toml
+++ b/crates/ere-sp1/Cargo.toml
@@ -14,6 +14,9 @@ bincode = "1.3"
 thiserror = "2"
 tracing = "0.1"
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [lib]
 name = "ere_succinct"
 path = "src/lib.rs"

--- a/crates/ere-sp1/build.rs
+++ b/crates/ere-sp1/build.rs
@@ -1,0 +1,5 @@
+use build_utils::gen_name_and_sdk_version;
+
+fn main() {
+    gen_name_and_sdk_version("sp1", "sp1-sdk");
+}

--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -13,6 +13,8 @@ use zkvm_interface::{
     ProverResourceType, zkVM, zkVMError,
 };
 
+include!(concat!(env!("OUT_DIR"), "/sdk_version.rs"));
+
 mod compile;
 
 mod error;

--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -13,7 +13,7 @@ use zkvm_interface::{
     ProverResourceType, zkVM, zkVMError,
 };
 
-include!(concat!(env!("OUT_DIR"), "/sdk_version.rs"));
+include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
 
 mod compile;
 
@@ -213,6 +213,14 @@ impl zkVM for EreSP1 {
 
         let client = Self::create_client(&self.resource);
         client.verify(&proof, &self.vk).map_err(zkVMError::from)
+    }
+
+    fn name() -> &'static str {
+        NAME
+    }
+
+    fn sdk_version() -> &'static str {
+        SDK_VERSION
     }
 }
 

--- a/crates/ere-zisk/Cargo.toml
+++ b/crates/ere-zisk/Cargo.toml
@@ -15,6 +15,9 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 blake3 = "1.3.1"
 
+[build-dependencies]
+build-utils = { workspace = true }
+
 [lib]
 name = "ere_zisk"
 path = "src/lib.rs"

--- a/crates/ere-zisk/build.rs
+++ b/crates/ere-zisk/build.rs
@@ -1,23 +1,5 @@
-use std::process::Command;
-
 use build_utils::gen_name_and_sdk_version;
 
 fn main() {
-    let out = Command::new("cargo-zisk")
-        .arg("--version")
-        .output()
-        .expect("failed to execute cargo-zisk --version");
-
-    if !out.status.success() {
-        panic!("cargo-zisk exited with {}", out.status);
-    }
-
-    // Example stdout:  "cargo-zisk 0.8.1 (f9a3655 2025-05-19T16:57:59.442084351Z)"
-    let text = std::str::from_utf8(&out.stdout).expect("cargo-zisk --version output");
-    let version = text
-        .split_whitespace()
-        .nth(1)
-        .expect("unexpected --version format");
-
-    gen_name_and_sdk_version("zisk", version);
+    gen_name_and_sdk_version("zisk", "0.8.1");
 }

--- a/crates/ere-zisk/build.rs
+++ b/crates/ere-zisk/build.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+
+use build_utils::gen_name_and_sdk_version;
+
+fn main() {
+    let out = Command::new("cargo-zisk")
+        .arg("--version")
+        .output()
+        .expect("failed to execute cargo-zisk --version");
+
+    if !out.status.success() {
+        panic!("cargo-zisk exited with {}", out.status);
+    }
+
+    // Example stdout:  "cargo-zisk 0.8.1 (f9a3655 2025-05-19T16:57:59.442084351Z)"
+    let text = std::str::from_utf8(&out.stdout).expect("cargo-zisk --version output");
+    let version = text
+        .split_whitespace()
+        .nth(1)
+        .expect("unexpected --version format");
+
+    gen_name_and_sdk_version("zisk", version);
+}

--- a/crates/ere-zisk/src/lib.rs
+++ b/crates/ere-zisk/src/lib.rs
@@ -16,6 +16,8 @@ use zkvm_interface::{
     zkVMError,
 };
 
+include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
+
 mod compile;
 mod error;
 
@@ -187,7 +189,9 @@ impl zkVM for EreZisk {
                 unimplemented!()
             }
             ProverResourceType::Network(_) => {
-                panic!("Network proving not yet implemented for ZisK. Use CPU or GPU resource type.");
+                panic!(
+                    "Network proving not yet implemented for ZisK. Use CPU or GPU resource type."
+                );
             }
         }
         let proving_time = start.elapsed();
@@ -242,6 +246,14 @@ impl zkVM for EreZisk {
         }
 
         Ok(())
+    }
+
+    fn name() -> &'static str {
+        NAME
+    }
+
+    fn sdk_version() -> &'static str {
+        SDK_VERSION
     }
 }
 

--- a/crates/zkvm-interface/src/lib.rs
+++ b/crates/zkvm-interface/src/lib.rs
@@ -81,4 +81,10 @@ pub trait zkVM {
     /// TODO: We can also just have this return the public inputs, but then the user needs
     /// TODO: ensure they check it for correct #[must_use]
     fn verify(&self, proof: &[u8]) -> Result<(), zkVMError>;
+
+    /// Returns the name of the zkVM
+    fn name() -> &'static str;
+
+    /// Returns the version of the zkVM SDK (e.g. 0.1.0)
+    fn sdk_version() -> &'static str;
 }

--- a/tests/pico/compile/basic/Cargo.toml
+++ b/tests/pico/compile/basic/Cargo.toml
@@ -1,11 +1,7 @@
 [workspace]
-members = [ 
-    "lib",
-    "app", 
-    "prover",
-]
+members = ["lib", "app", "prover"]
 resolver = "2"
 
 [workspace.dependencies]
-pico-sdk = { git = "https://github.com/brevis-network/pico" }
+pico-sdk = { git = "https://github.com/brevis-network/pico", tag = "v1.1.4" }
 serde = { version = "1.0.205", features = ["derive"] }

--- a/tests/sp1/compile/basic/Cargo.toml
+++ b/tests/sp1/compile/basic/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git" }
+sp1-zkvm = "5.0.5"

--- a/tests/sp1/execute/basic/Cargo.toml
+++ b/tests/sp1/execute/basic/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git" }
+sp1-zkvm = "5.0.5"

--- a/tests/sp1/prove/basic/Cargo.toml
+++ b/tests/sp1/prove/basic/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git" }
+sp1-zkvm = "5.0.5"


### PR DESCRIPTION
This PR adds a new mechanism that allows defining for each zkVM ere implementation:
- The name as a constant.
- The SDK version is automatically detected in the build phase.

This feature is used by `zkevm-benchmark-workload` to create a proper full name for the output results. For more information, see https://github.com/eth-act/zkevm-benchmark-workload/pull/104.

This PR is in draft mode to get early feedback. If it makes sense, it would be applied to the rest of the current zkVM implementations.