### PR TITLE
Add multi-gpu proving for risc0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,15 +325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,7 +951,7 @@ dependencies = [
  "arrayvec",
  "bitcode_derive",
  "bytemuck",
- "glam 0.30.3",
+ "glam",
  "serde",
 ]
 
@@ -1668,52 +1659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cust"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6cc71911e179f12483b9734120b45bd00bf64fab085cc4818428523eedd469"
-dependencies = [
- "bitflags 1.3.2",
- "bytemuck",
- "cust_core",
- "cust_derive",
- "cust_raw",
- "find_cuda_helper",
-]
-
-[[package]]
-name = "cust_core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f79662cb8f890cbf335e818cd522d6e3a53fe63f61d1aaaf859cd3d975f06"
-dependencies = [
- "cust_derive",
- "glam 0.20.5",
- "mint",
- "vek",
-]
-
-[[package]]
-name = "cust_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3bc95fe629aed92b2423de6ccff9e40174b21d19cb6ee6281a4d04ac72f66"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cust_raw"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf40d6ade12cb9828bbc844b9875c7b93d25e67a3c9bf61c7aa3ae09e402bf8"
-dependencies = [
- "find_cuda_helper",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,12 +2343,17 @@ name = "ere-risc0"
 version = "0.0.11"
 dependencies = [
  "anyhow",
+ "bincode",
+ "bonsai-sdk",
  "borsh",
  "build-utils",
+ "bytemuck",
  "cargo_metadata 0.19.2",
  "risc0-build",
  "risc0-zkvm",
  "serde",
+ "serde_yaml",
+ "tempfile",
  "thiserror 2.0.12",
  "tracing",
  "zkvm-interface",
@@ -2547,15 +2497,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "find_cuda_helper"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
-dependencies = [
- "glob",
-]
 
 [[package]]
 name = "findshlibs"
@@ -2859,15 +2800,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glam"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "glam"
@@ -3211,15 +3143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3905,12 +3828,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -4217,12 +4134,6 @@ checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
-
-[[package]]
-name = "mint"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
@@ -7740,13 +7651,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43afb4572af3b812fb0c83bfac5014041af10937288dcb67b7f9cea649483ff8"
 dependencies = [
  "cc",
- "cust",
  "derive_more 2.0.1",
  "glob",
  "risc0-build-kernel",
  "risc0-core",
  "risc0-sys",
- "sppark",
 ]
 
 [[package]]
@@ -7758,7 +7667,6 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cfg-if",
- "cust",
  "downloader",
  "hex",
  "lazy-regex",
@@ -7785,7 +7693,6 @@ dependencies = [
  "risc0-build-kernel",
  "risc0-core",
  "risc0-sys",
- "sppark",
 ]
 
 [[package]]
@@ -7827,13 +7734,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5e586b310d20fab3f141a318704ded77c20ace155af4db1b6594bd60579b90"
 dependencies = [
  "cc",
- "cust",
  "derive_more 2.0.1",
  "glob",
  "risc0-build-kernel",
  "risc0-core",
  "risc0-sys",
- "sppark",
 ]
 
 [[package]]
@@ -7881,9 +7786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11abd6064c039f24b58676419cd13c92cbf4858e66948dd55b188b03511db44c"
 dependencies = [
  "anyhow",
- "cust",
  "risc0-build-kernel",
- "sppark",
 ]
 
 [[package]]
@@ -7907,7 +7810,6 @@ dependencies = [
  "borsh",
  "bytemuck",
  "cfg-if",
- "cust",
  "digest 0.10.7",
  "ff 0.13.1",
  "hex",
@@ -8129,19 +8031,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -8149,7 +8038,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -8510,6 +8399,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.10.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -9167,16 +9069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sppark"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdc4f02f557e3037bbe2a379cac8be6e014a67beb7bf0996b536979392f6361"
-dependencies = [
- "cc",
- "which",
-]
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9481,7 +9373,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -10143,6 +10035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10213,18 +10111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "vek"
-version = "0.15.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8085882662f9bc47fc8b0cdafa5e19df8f592f650c02b9083da8d45ac9eebd17"
-dependencies = [
- "approx",
- "num-integer",
- "num-traits",
- "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -10392,18 +10278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ erased-serde = "0.4.6"
 indexmap = "2.10.0"
 serde = "1.0.219"
 serde_json = "1.0.142"
+serde_yaml = "0.9.34"
 tempfile = "3.20.0"
 thiserror = "2.0.12"
 toml = "0.8.23"
@@ -68,6 +69,7 @@ pico-sdk = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.4" 
 # Risc0 dependencies
 risc0-build = "2.3.1"
 risc0-zkvm = { version = "2.3.1", default-features = false }
+bonsai-sdk = { version = "1.4.0" }
 
 # SP1 dependencies
 sp1-sdk = "5.1.0"

--- a/crates/ere-cli/src/main.rs
+++ b/crates/ere-cli/src/main.rs
@@ -190,7 +190,7 @@ fn construct_zkvm(program_path: PathBuf, resource: ProverResourceType) -> Result
     let zkvm = Ok::<_, Error>(ere_pico::ErePico::new(program, resource));
 
     #[cfg(feature = "risc0")]
-    let zkvm = Ok::<_, Error>(ere_risc0::EreRisc0::new(program, resource));
+    let zkvm = ere_risc0::EreRisc0::new(program, resource);
 
     #[cfg(feature = "sp1")]
     let zkvm = Ok::<_, Error>(ere_sp1::EreSP1::new(program, resource));

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -365,6 +365,7 @@ impl zkVM for EreDockerizedzkVM {
                     cmd = cmd
                         .mount_docker_socket()
                         .network("host")
+                        .inherit_env("CUDA_VISIBLE_DEVICES")
                         .inherit_env("SEGMENT_SIZE")
                         .inherit_env("RISC0_KECCAK_PO2")
                 }

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -356,11 +356,18 @@ impl zkVM for EreDockerizedzkVM {
         if matches!(self.resource, ProverResourceType::Gpu) {
             cmd = cmd.gpus("all");
 
-            // SP1's GPU proving requires Docker to start GPU prover service, to
-            // give the client access to the prover service, we need to use the
-            // host networking driver.
+            // SP1's and Risc0's GPU proving requires Docker to start GPU prover
+            // service, to give the client access to the prover service, we need
+            // to use the host networking driver.
             match self.zkvm {
-                ErezkVM::SP1 | ErezkVM::Risc0 => cmd = cmd.mount_docker_socket().network("host"),
+                ErezkVM::SP1 => cmd = cmd.mount_docker_socket().network("host"),
+                ErezkVM::Risc0 => {
+                    cmd = cmd
+                        .mount_docker_socket()
+                        .network("host")
+                        .inherit_env("SEGMENT_SIZE")
+                        .inherit_env("RISC0_KECCAK_PO2")
+                }
                 _ => {}
             }
         }

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -354,8 +354,6 @@ impl zkVM for EreDockerizedzkVM {
             .volume(tempdir.path(), "/workspace");
 
         if matches!(self.resource, ProverResourceType::Gpu) {
-            cmd = cmd.gpus("all");
-
             // SP1's and Risc0's GPU proving requires Docker to start GPU prover
             // service, to give the client access to the prover service, we need
             // to use the host networking driver.

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -240,6 +240,7 @@ impl Compiler for EreDockerizedCompiler {
         DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
             .inherit_env("RUST_LOG")
+            .inherit_env("NO_COLOR")
             .volume(&self.mount_directory, "/guest")
             .volume(tempdir.path(), "/guest-output")
             .exec([
@@ -308,6 +309,7 @@ impl zkVM for EreDockerizedzkVM {
         DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
             .inherit_env("RUST_LOG")
+            .inherit_env("NO_COLOR")
             .volume(tempdir.path(), "/workspace")
             .exec([
                 "execute",
@@ -351,6 +353,7 @@ impl zkVM for EreDockerizedzkVM {
         let mut cmd = DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
             .inherit_env("RUST_LOG")
+            .inherit_env("NO_COLOR")
             .volume(tempdir.path(), "/workspace");
 
         if matches!(self.resource, ProverResourceType::Gpu) {
@@ -416,6 +419,7 @@ impl zkVM for EreDockerizedzkVM {
         DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
             .inherit_env("RUST_LOG")
+            .inherit_env("NO_COLOR")
             .volume(tempdir.path(), "/workspace")
             .exec([
                 "verify",

--- a/crates/ere-risc0/Cargo.toml
+++ b/crates/ere-risc0/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-bincode = { workspace = true }
+bincode.workspace = true
 borsh.workspace = true
-bytemuck = { workspace = true }
+bytemuck.workspace = true
 cargo_metadata.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
-serde_yaml = { workspace = true }
+serde_yaml.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -20,7 +20,7 @@ tracing.workspace = true
 # Risc0 dependencies
 risc0-build = { workspace = true, default-features = true, features = ["unstable"] }
 risc0-zkvm = { workspace = true, default-features = true, features = ["unstable"] }
-bonsai-sdk = { workspace = true }
+bonsai-sdk.workspace = true
 
 # Local dependencies
 zkvm-interface.workspace = true

--- a/crates/ere-risc0/Cargo.toml
+++ b/crates/ere-risc0/Cargo.toml
@@ -7,15 +7,20 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bincode = { workspace = true }
 borsh.workspace = true
+bytemuck = { workspace = true }
 cargo_metadata.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
+serde_yaml = { workspace = true }
+tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
 # Risc0 dependencies
 risc0-build = { workspace = true, default-features = true, features = ["unstable"] }
 risc0-zkvm = { workspace = true, default-features = true, features = ["unstable"] }
+bonsai-sdk = { workspace = true }
 
 # Local dependencies
 zkvm-interface.workspace = true
@@ -25,7 +30,6 @@ build-utils.workspace = true
 
 [features]
 metal = ["risc0-zkvm/metal"]
-cuda = ["risc0-zkvm/cuda"]
 
 [lints]
 workspace = true

--- a/crates/ere-risc0/compose.yml
+++ b/crates/ere-risc0/compose.yml
@@ -1,4 +1,7 @@
-name: bento
+# Copied and modified from https://github.com/risc0/risc0/blob/v2.3.1/compose.yml.
+
+# MODIFIED: Use ere-risc0 as project name
+name: ere-risc0
 services:
   redis:
     hostname: ${REDIS_HOST}
@@ -44,42 +47,47 @@ services:
       timeout: 5s
       retries: 5
 
-  grafana:
-    image: ${GRAFANA_IMG}
-    restart: unless-stopped
-    ports:
-     - '3000:3000'
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_LOG_LEVEL=WARN
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_PORT={POSTGRES_PORT}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASS=${POSTGRES_PASSWORD}
-    volumes:
-      - ./grafana:/etc/grafana/provisioning/
-      - grafana-data:/var/lib/grafana
-    depends_on:
-      - postgres
-      - redis
-      - minio
+  # MODIFIED: Commented-out to avoid unnecessary resource waste.
+  # grafana:
+  #   image: ${GRAFANA_IMG}
+  #   restart: unless-stopped
+  #   ports:
+  #     - '3000:3000'
+  #   environment:
+  #     - GF_SECURITY_ADMIN_USER=admin
+  #     - GF_SECURITY_ADMIN_PASSWORD=admin
+  #     - GF_LOG_LEVEL=WARN
+  #     - POSTGRES_HOST=${POSTGRES_HOST}
+  #     - POSTGRES_DB=${POSTGRES_DB}
+  #     - POSTGRES_PORT={POSTGRES_PORT}
+  #     - POSTGRES_USER=${POSTGRES_USER}
+  #     - POSTGRES_PASS=${POSTGRES_PASSWORD}
+  #   volumes:
+  #     - ./grafana:/etc/grafana/provisioning/
+  #     - grafana-data:/var/lib/grafana
+  #   depends_on:
+  #     - postgres
+  #     - redis
+  #     - minio
 
   exec_agent:
-    image: agent
+    # MODIFIED: Specify the pre-built image.
+    image: ere-risc0/agent:${RISC0_VERSION}
     runtime: nvidia
+    # MODIFIED: Added to avoid image pulling.
+    pull_policy: never
     restart: always
     depends_on:
       - postgres
       - redis
       - minio
-    build:
-      context: .
-      dockerfile: bento/dockerfiles/agent.dockerfile
-      args:
-        NVCC_APPEND_FLAGS: "--gpu-architecture=compute_86 --gpu-code=compute_86,sm_86 --generate-code arch=compute_86,code=sm_86"
-        CUDA_OPT_LEVEL: 1
+    # MODIFIED: Commented-out because the image should be pre-built.
+    # build:
+    #   context: .
+    #   dockerfile: bento/dockerfiles/agent.dockerfile
+    #   args:
+    #     NVCC_APPEND_FLAGS: "--gpu-architecture=compute_86 --gpu-code=compute_86,sm_86 --generate-code arch=compute_86,code=sm_86"
+    #     CUDA_OPT_LEVEL: 1
     mem_limit: 4G
     cpu_count: 4
     environment:
@@ -91,15 +99,18 @@ services:
       S3_ACCESS_KEY: ${MINIO_ROOT_USER}
       S3_SECRET_KEY: ${MINIO_ROOT_PASS}
       RUST_LOG: ${RUST_LOG}
+      # MODIFIED: Added to set log color
+      NO_COLOR: ${NO_COLOR}
       RUST_BACKTRACE: 1
       RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2}
-      # Enable / disable along with gpu_*_agent*
-      # JOIN_STREAM: 1
-      # COPROC_STREAM: 1
+    # Enable / disable along with gpu_*_agent*
+    # JOIN_STREAM: 1
+    # COPROC_STREAM: 1
     entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE}
 
   aux_agent:
-    image: agent
+    # MODIFIED: Specify the pre-built image.
+    image: ere-risc0/agent:${RISC0_VERSION}
     runtime: nvidia
     pull_policy: never
     restart: always
@@ -117,73 +128,80 @@ services:
       S3_ACCESS_KEY: ${MINIO_ROOT_USER}
       S3_SECRET_KEY: ${MINIO_ROOT_PASS}
       RUST_LOG: ${RUST_LOG}
+      # MODIFIED: Added to set log color
+      NO_COLOR: ${NO_COLOR}
       RUST_BACKTRACE: 1
     # NOTE: if adding more aux workers, only one needs --monitor-requeue (for task reaping)
     entrypoint: /app/agent -t aux --monitor-requeue
 
-  gpu_prove_agent0: &gpu
-    image: agent
-    runtime: nvidia
-    pull_policy: never
-    restart: always
-    depends_on:
-      - postgres
-      - redis
-      - minio
-    mem_limit: 4G
-    cpu_count: 4
-    environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-      REDIS_URL: redis://${REDIS_HOST}:6379
-      S3_URL: http://${MINIO_HOST}:9000
-      S3_BUCKET: ${MINIO_BUCKET}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
-      RUST_LOG: ${RUST_LOG}
-      RUST_BACKTRACE: 1
-    entrypoint: /app/agent -t prove
-    # comment-out if running in CPU proving mode
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              # TODO: how to scale this with N gpus?
-              device_ids: ['0']
-              capabilities: [gpu]
+  # MODIFIED: Moved to `gpu_prover_agent.yml` as template.
+  # gpu_prove_agent0: &gpu
+  #   image: agent
+  #   runtime: nvidia
+  #   pull_policy: never
+  #   restart: always
+  #   depends_on:
+  #     - postgres
+  #     - redis
+  #     - minio
+  #   mem_limit: 4G
+  #   cpu_count: 4
+  #   environment:
+  #     DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+  #     REDIS_URL: redis://${REDIS_HOST}:6379
+  #     S3_URL: http://${MINIO_HOST}:9000
+  #     S3_BUCKET: ${MINIO_BUCKET}
+  #     S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+  #     S3_SECRET_KEY: ${MINIO_ROOT_PASS}
+  #     RUST_LOG: ${RUST_LOG}
+  #     RUST_BACKTRACE: 1
+  #   entrypoint: /app/agent -t prove
+  #   # comment-out if running in CPU proving mode
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             # TODO: how to scale this with N gpus?
+  #             device_ids: ['0']
+  #             capabilities: [gpu]
 
-  snark_agent:
-    image: agent
-    runtime: nvidia
-    pull_policy: never
-    restart: always
-    depends_on:
-      - postgres
-      - redis
-      - minio
-    environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-      REDIS_URL: redis://${REDIS_HOST}:6379
-      S3_URL: http://${MINIO_HOST}:9000
-      S3_BUCKET: ${MINIO_BUCKET}
-      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
-      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
-      RUST_LOG: ${RUST_LOG}
-      RUST_BACKTRACE: 1
-    entrypoint: /app/agent -t snark
-    ulimits:
-      # Needed for stark_verify bin
-      # TODO: this number was just guess and check found
-      stack: 90000000
+  # MODIFIED: Commented-out because we don't need to wrap it for on-chain verification.
+  # snark_agent:
+  #   image: agent
+  #   runtime: nvidia
+  #   pull_policy: never
+  #   restart: always
+  #   depends_on:
+  #     - postgres
+  #     - redis
+  #     - minio
+  #   environment:
+  #     DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+  #     REDIS_URL: redis://${REDIS_HOST}:6379
+  #     S3_URL: http://${MINIO_HOST}:9000
+  #     S3_BUCKET: ${MINIO_BUCKET}
+  #     S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+  #     S3_SECRET_KEY: ${MINIO_ROOT_PASS}
+  #     RUST_LOG: ${RUST_LOG}
+  #     RUST_BACKTRACE: 1
+  #   entrypoint: /app/agent -t snark
+  #   ulimits:
+  #     # Needed for stark_verify bin
+  #     # TODO: this number was just guess and check found
+  #     stack: 90000000
 
   rest_api:
+    # MODIFIED: Specify the pre-built image.
+    image: ere-risc0/rest_api:${RISC0_VERSION}
     restart: always
     depends_on:
       - postgres
       - minio
-    build:
-      context: .
-      dockerfile: bento/dockerfiles/rest_api.dockerfile
+    # MODIFIED: Commented-out because the image should be pre-built.
+    # build:
+    #   context: .
+    #   dockerfile: bento/dockerfiles/rest_api.dockerfile
     mem_limit: 1G
     cpu_count: 1
     environment:
@@ -193,6 +211,8 @@ services:
       S3_ACCESS_KEY: ${MINIO_ROOT_USER}
       S3_SECRET_KEY: ${MINIO_ROOT_PASS}
       RUST_LOG: ${RUST_LOG}
+      # MODIFIED: Added to set log color
+      NO_COLOR: ${NO_COLOR}
       RUST_BACKTRACE: 1
     ports:
       - '8081:8081'
@@ -202,4 +222,5 @@ volumes:
   redis-data:
   postgres-data:
   minio-data:
-  grafana-data:
+  # MODIFIED: Commented-out to avoid unnecessary resource waste.
+  # grafana-data:

--- a/crates/ere-risc0/compose.yml
+++ b/crates/ere-risc0/compose.yml
@@ -1,0 +1,118 @@
+# Copied and modified from https://github.com/risc0/risc0/blob/main/compose.yml.
+
+name: ere-risc0
+services:
+  redis:
+    hostname: redis
+    image: redis:7.2.5-alpine3.19
+    restart: always
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-data:/data
+
+  postgres:
+    hostname: postgres
+    image: postgres:16.3-bullseye
+    restart: always
+    environment:
+      POSTGRES_DB: taskdb
+      POSTGRES_USER: worker
+      POSTGRES_PASSWORD: password
+    expose:
+      - '5432'
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    command: -p 5432
+
+  minio:
+    hostname: minio
+    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    volumes:
+      - minio-data:/data
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+      - MINIO_DEFAULT_BUCKETS=workflow
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  exec_agent:
+    image: ere-risc0/agent:${RISC0_VERSION}
+    runtime: nvidia
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+      - minio
+    mem_limit: 4G
+    cpu_count: 4
+    environment:
+      DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
+      REDIS_URL: redis://redis:6379
+      S3_URL: http://minio:9000
+      S3_BUCKET: workflow
+      # TODO: create a lower perm user on startup of minio to use for agents
+      S3_ACCESS_KEY: admin
+      S3_SECRET_KEY: password
+      RUST_LOG: ${RUST_LOG}
+      RUST_BACKTRACE: 1
+      RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2}
+    entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE}
+
+  aux_agent:
+    image: ere-risc0/agent:${RISC0_VERSION}
+    runtime: nvidia
+    pull_policy: never
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+      - minio
+    mem_limit: 256M
+    cpu_count: 1
+    environment:
+      DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
+      REDIS_URL: redis://redis:6379
+      S3_URL: http://minio:9000
+      S3_BUCKET: workflow
+      S3_ACCESS_KEY: admin
+      S3_SECRET_KEY: password
+      RUST_LOG: ${RUST_LOG}
+      RUST_BACKTRACE: 1
+    # NOTE: if adding more aux workers, only one needs --monitor-requeue (for task reaping)
+    entrypoint: /app/agent -t aux --monitor-requeue
+
+  rest_api:
+    image: ere-risc0/rest_api:${RISC0_VERSION}
+    restart: always
+    depends_on:
+      - postgres
+      - minio
+    mem_limit: 1G
+    cpu_count: 1
+    environment:
+      DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
+      S3_URL: http://minio:9000
+      S3_BUCKET: workflow
+      S3_ACCESS_KEY: admin
+      S3_SECRET_KEY: password
+      RUST_LOG: ${RUST_LOG}
+      RUST_BACKTRACE: 1
+    ports:
+      - '8081:8081'
+    entrypoint: /app/rest_api --bind-addr 0.0.0.0:8081
+
+volumes:
+  redis-data:
+  postgres-data:
+  minio-data:

--- a/crates/ere-risc0/compose.yml
+++ b/crates/ere-risc0/compose.yml
@@ -1,10 +1,8 @@
-# Copied and modified from https://github.com/risc0/risc0/blob/main/compose.yml.
-
-name: ere-risc0
+name: bento
 services:
   redis:
-    hostname: redis
-    image: redis:7.2.5-alpine3.19
+    hostname: ${REDIS_HOST}
+    image: ${REDIS_IMG}
     restart: always
     ports:
       - 6379:6379
@@ -12,24 +10,24 @@ services:
       - redis-data:/data
 
   postgres:
-    hostname: postgres
-    image: postgres:16.3-bullseye
+    hostname: ${POSTGRES_HOST}
+    image: ${POSTGRES_IMG}
     restart: always
     environment:
-      POSTGRES_DB: taskdb
-      POSTGRES_USER: worker
-      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     expose:
-      - '5432'
+      - '${POSTGRES_PORT}'
     ports:
-      - '5432:5432'
+      - '${POSTGRES_PORT}:${POSTGRES_PORT}'
     volumes:
       - postgres-data:/var/lib/postgresql/data
-    command: -p 5432
+    command: -p ${POSTGRES_PORT}
 
   minio:
-    hostname: minio
-    image: minio/minio:RELEASE.2024-05-28T17-19-04Z
+    hostname: ${MINIO_HOST}
+    image: ${MINIO_IMG}
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -37,40 +35,71 @@ services:
       - minio-data:/data
     command: server /data --console-address ":9001"
     environment:
-      - MINIO_ROOT_USER=admin
-      - MINIO_ROOT_PASSWORD=password
-      - MINIO_DEFAULT_BUCKETS=workflow
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASS}
+      - MINIO_DEFAULT_BUCKETS=${MINIO_BUCKET}
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 5s
       retries: 5
 
+  grafana:
+    image: ${GRAFANA_IMG}
+    restart: unless-stopped
+    ports:
+     - '3000:3000'
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_LOG_LEVEL=WARN
+      - POSTGRES_HOST=${POSTGRES_HOST}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_PORT={POSTGRES_PORT}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASS=${POSTGRES_PASSWORD}
+    volumes:
+      - ./grafana:/etc/grafana/provisioning/
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - postgres
+      - redis
+      - minio
+
   exec_agent:
-    image: ere-risc0/agent:${RISC0_VERSION}
+    image: agent
     runtime: nvidia
     restart: always
     depends_on:
       - postgres
       - redis
       - minio
+    build:
+      context: .
+      dockerfile: bento/dockerfiles/agent.dockerfile
+      args:
+        NVCC_APPEND_FLAGS: "--gpu-architecture=compute_86 --gpu-code=compute_86,sm_86 --generate-code arch=compute_86,code=sm_86"
+        CUDA_OPT_LEVEL: 1
     mem_limit: 4G
     cpu_count: 4
     environment:
-      DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
-      REDIS_URL: redis://redis:6379
-      S3_URL: http://minio:9000
-      S3_BUCKET: workflow
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      REDIS_URL: redis://${REDIS_HOST}:6379
+      S3_URL: http://${MINIO_HOST}:9000
+      S3_BUCKET: ${MINIO_BUCKET}
       # TODO: create a lower perm user on startup of minio to use for agents
-      S3_ACCESS_KEY: admin
-      S3_SECRET_KEY: password
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
       RUST_LOG: ${RUST_LOG}
       RUST_BACKTRACE: 1
       RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2}
+      # Enable / disable along with gpu_*_agent*
+      # JOIN_STREAM: 1
+      # COPROC_STREAM: 1
     entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE}
 
   aux_agent:
-    image: ere-risc0/agent:${RISC0_VERSION}
+    image: agent
     runtime: nvidia
     pull_policy: never
     restart: always
@@ -81,31 +110,88 @@ services:
     mem_limit: 256M
     cpu_count: 1
     environment:
-      DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
-      REDIS_URL: redis://redis:6379
-      S3_URL: http://minio:9000
-      S3_BUCKET: workflow
-      S3_ACCESS_KEY: admin
-      S3_SECRET_KEY: password
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      REDIS_URL: redis://${REDIS_HOST}:6379
+      S3_URL: http://${MINIO_HOST}:9000
+      S3_BUCKET: ${MINIO_BUCKET}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
       RUST_LOG: ${RUST_LOG}
       RUST_BACKTRACE: 1
     # NOTE: if adding more aux workers, only one needs --monitor-requeue (for task reaping)
     entrypoint: /app/agent -t aux --monitor-requeue
 
+  gpu_prove_agent0: &gpu
+    image: agent
+    runtime: nvidia
+    pull_policy: never
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+      - minio
+    mem_limit: 4G
+    cpu_count: 4
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      REDIS_URL: redis://${REDIS_HOST}:6379
+      S3_URL: http://${MINIO_HOST}:9000
+      S3_BUCKET: ${MINIO_BUCKET}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
+      RUST_LOG: ${RUST_LOG}
+      RUST_BACKTRACE: 1
+    entrypoint: /app/agent -t prove
+    # comment-out if running in CPU proving mode
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              # TODO: how to scale this with N gpus?
+              device_ids: ['0']
+              capabilities: [gpu]
+
+  snark_agent:
+    image: agent
+    runtime: nvidia
+    pull_policy: never
+    restart: always
+    depends_on:
+      - postgres
+      - redis
+      - minio
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      REDIS_URL: redis://${REDIS_HOST}:6379
+      S3_URL: http://${MINIO_HOST}:9000
+      S3_BUCKET: ${MINIO_BUCKET}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
+      RUST_LOG: ${RUST_LOG}
+      RUST_BACKTRACE: 1
+    entrypoint: /app/agent -t snark
+    ulimits:
+      # Needed for stark_verify bin
+      # TODO: this number was just guess and check found
+      stack: 90000000
+
   rest_api:
-    image: ere-risc0/rest_api:${RISC0_VERSION}
     restart: always
     depends_on:
       - postgres
       - minio
+    build:
+      context: .
+      dockerfile: bento/dockerfiles/rest_api.dockerfile
     mem_limit: 1G
     cpu_count: 1
     environment:
-      DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
-      S3_URL: http://minio:9000
-      S3_BUCKET: workflow
-      S3_ACCESS_KEY: admin
-      S3_SECRET_KEY: password
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+      S3_URL: http://${MINIO_HOST}:9000
+      S3_BUCKET: ${MINIO_BUCKET}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASS}
       RUST_LOG: ${RUST_LOG}
       RUST_BACKTRACE: 1
     ports:
@@ -116,3 +202,4 @@ volumes:
   redis-data:
   postgres-data:
   minio-data:
+  grafana-data:

--- a/crates/ere-risc0/gpu_prover_agent.yml
+++ b/crates/ere-risc0/gpu_prover_agent.yml
@@ -1,4 +1,12 @@
-image: agent
+# Copied and modified from https://github.com/risc0/risc0/blob/v2.3.1/compose.yml.
+# In runtime, `ere-risc0` will check env `CUDA_VISIBLE_DEVICES`:
+# If it's not set, it will spin up a container of the following service with all
+# GPUs access
+# If it's set to some device ids, it will spin up containers and each will have
+# 1 GPU access.
+
+# MODIFIED: Rename to local image with namespace and version tag.
+image: ere-risc0/agent:${RISC0_VERSION}
 runtime: nvidia
 pull_policy: never
 restart: always
@@ -16,6 +24,8 @@ environment:
   S3_ACCESS_KEY: ${MINIO_ROOT_USER}
   S3_SECRET_KEY: ${MINIO_ROOT_PASS}
   RUST_LOG: ${RUST_LOG}
+  # MODIFIED: Added to set log color
+  NO_COLOR: ${NO_COLOR}
   RUST_BACKTRACE: 1
 entrypoint: /app/agent -t prove
 # comment-out if running in CPU proving mode

--- a/crates/ere-risc0/gpu_prover_agent.yml
+++ b/crates/ere-risc0/gpu_prover_agent.yml
@@ -1,0 +1,27 @@
+image: ere-risc0/agent:${RISC0_VERSION}
+runtime: nvidia
+pull_policy: never
+restart: always
+depends_on:
+  - postgres
+  - redis
+  - minio
+mem_limit: 4G
+cpu_count: 4
+environment:
+  DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
+  REDIS_URL: redis://redis:6379
+  S3_URL: http://minio:9000
+  S3_BUCKET: workflow
+  S3_ACCESS_KEY: admin
+  S3_SECRET_KEY: password
+  RUST_LOG: ${RUST_LOG}
+  RUST_BACKTRACE: 1
+entrypoint: /app/agent -t prove
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          device_ids: ['0']
+          capabilities: [gpu]

--- a/crates/ere-risc0/gpu_prover_agent.yml
+++ b/crates/ere-risc0/gpu_prover_agent.yml
@@ -1,4 +1,4 @@
-image: ere-risc0/agent:${RISC0_VERSION}
+image: agent
 runtime: nvidia
 pull_policy: never
 restart: always
@@ -9,19 +9,21 @@ depends_on:
 mem_limit: 4G
 cpu_count: 4
 environment:
-  DATABASE_URL: postgresql://worker:password@postgres:5432/taskdb
-  REDIS_URL: redis://redis:6379
-  S3_URL: http://minio:9000
-  S3_BUCKET: workflow
-  S3_ACCESS_KEY: admin
-  S3_SECRET_KEY: password
+  DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+  REDIS_URL: redis://${REDIS_HOST}:6379
+  S3_URL: http://${MINIO_HOST}:9000
+  S3_BUCKET: ${MINIO_BUCKET}
+  S3_ACCESS_KEY: ${MINIO_ROOT_USER}
+  S3_SECRET_KEY: ${MINIO_ROOT_PASS}
   RUST_LOG: ${RUST_LOG}
   RUST_BACKTRACE: 1
 entrypoint: /app/agent -t prove
+# comment-out if running in CPU proving mode
 deploy:
   resources:
     reservations:
       devices:
         - driver: nvidia
+          # TODO: how to scale this with N gpus?
           device_ids: ['0']
           capabilities: [gpu]

--- a/crates/ere-risc0/sample.env
+++ b/crates/ere-risc0/sample.env
@@ -1,0 +1,24 @@
+# Prover node configs
+
+RUST_LOG=info
+
+REDIS_HOST=redis
+REDIS_IMG=redis:7.2.5-alpine3.19
+
+POSTGRES_HOST=postgres
+POSTGRES_IMG=postgres:16.3-bullseye
+POSTGRES_DB=taskdb
+POSTGRES_PORT=5432
+POSTGRES_USER=worker
+POSTGRES_PASSWORD=password
+
+MINIO_HOST=minio
+MINIO_IMG=minio/minio:RELEASE.2024-05-28T17-19-04Z
+MINIO_ROOT_USER=admin
+MINIO_ROOT_PASS=password
+MINIO_BUCKET=workflow
+
+GRAFANA_IMG=grafana/grafana:11.0.0
+
+SEGMENT_SIZE=21
+RISC0_KECCAK_PO2=17

--- a/crates/ere-risc0/sample.env
+++ b/crates/ere-risc0/sample.env
@@ -1,6 +1,10 @@
+# Copied and modified from https://github.com/risc0/risc0/blob/v2.3.1/compose.yml.
+
 # Prover node configs
 
 RUST_LOG=info
+# MODIFIED: Added to inherit from host.
+NO_COLOR=
 
 REDIS_HOST=redis
 REDIS_IMG=redis:7.2.5-alpine3.19

--- a/crates/ere-risc0/src/lib.rs
+++ b/crates/ere-risc0/src/lib.rs
@@ -1,10 +1,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use crate::error::Risc0Error;
-use compile::compile_risc0_program;
-use risc0_zkvm::{
-    ExecutorEnv, ExecutorEnvBuilder, ProverOpts, Receipt, default_executor, default_prover,
-};
+use crate::{compile::compile_risc0_program, error::Risc0Error};
+use risc0_zkvm::{ExecutorEnv, ExecutorEnvBuilder, Receipt, default_executor};
 use std::{path::Path, time::Instant};
 use zkvm_interface::{
     Compiler, Input, InputItem, ProgramExecutionReport, ProgramProvingReport, ProverResourceType,
@@ -15,6 +12,7 @@ include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
 
 mod compile;
 mod error;
+mod prove;
 
 pub use compile::Risc0Program;
 
@@ -31,38 +29,37 @@ impl Compiler for RV32_IM_RISC0_ZKVM_ELF {
     }
 }
 
+pub struct EreRisc0 {
+    program: <RV32_IM_RISC0_ZKVM_ELF as Compiler>::Program,
+    resource: ProverResourceType,
+}
+
 impl EreRisc0 {
     pub fn new(
         program: <RV32_IM_RISC0_ZKVM_ELF as Compiler>::Program,
-        resource_type: ProverResourceType,
-    ) -> Self {
-        match resource_type {
-            ProverResourceType::Cpu => {
-                #[cfg(any(feature = "cuda", feature = "metal"))]
-                panic!("CPU mode requires both 'cuda' and 'metal' features to be disabled");
-            }
+        resource: ProverResourceType,
+    ) -> Result<Self, zkVMError> {
+        match resource {
             ProverResourceType::Gpu => {
-                #[cfg(not(any(feature = "cuda", feature = "metal")))]
-                panic!("GPU selected but neither 'cuda' nor 'metal' feature is enabled");
+                // If not using Metal, we use the bento stack which requires
+                // Docker to spin up the proving services that use Cuda.
+                if !cfg!(feature = "metal") {
+                    prove::bento::build_bento_images()
+                        .map_err(|err| zkVMError::Other(Box::new(err)))?;
+                    prove::bento::docker_compose_bento_up()
+                        .map_err(|err| zkVMError::Other(Box::new(err)))?;
+                }
             }
             ProverResourceType::Network(_) => {
                 panic!(
                     "Network proving not yet implemented for RISC Zero. Use CPU or GPU resource type."
                 );
             }
+            _ => {}
         }
 
-        Self {
-            program,
-            resource_type,
-        }
+        Ok(Self { program, resource })
     }
-}
-
-pub struct EreRisc0 {
-    program: <RV32_IM_RISC0_ZKVM_ELF as Compiler>::Program,
-    #[allow(dead_code)]
-    resource_type: ProverResourceType,
 }
 
 impl zkVM for EreRisc0 {
@@ -84,19 +81,23 @@ impl zkVM for EreRisc0 {
     }
 
     fn prove(&self, inputs: &Input) -> Result<(Vec<u8>, ProgramProvingReport), zkVMError> {
-        let prover = default_prover();
-        let mut env = ExecutorEnv::builder();
-        serialize_inputs(&mut env, inputs).map_err(|err| zkVMError::Other(err.into()))?;
-        let env = env.build().map_err(|err| zkVMError::Other(err.into()))?;
+        let (receipt, proving_time) = match self.resource {
+            ProverResourceType::Cpu => prove::default::prove(&self.program, inputs)?,
+            ProverResourceType::Gpu => {
+                if cfg!(feature = "metal") {
+                    // The default prover selects the prover depends on the
+                    // feature flag, if non enabled, it executes the pre-installed
+                    // binary to generate the proof; if `metal` is enabled, it
+                    // uses the local built binary.
+                    prove::default::prove(&self.program, inputs)?
+                } else {
+                    prove::bento::prove(&self.program, inputs)?
+                }
+            }
+            ProverResourceType::Network(_) => unreachable!(),
+        };
 
-        let now = std::time::Instant::now();
-        let prove_info = prover
-            .prove_with_opts(env, &self.program.elf, &ProverOpts::succinct())
-            .map_err(|err| zkVMError::Other(err.into()))?;
-        let proving_time = now.elapsed();
-
-        let encoded =
-            borsh::to_vec(&prove_info.receipt).map_err(|err| zkVMError::Other(Box::new(err)))?;
+        let encoded = borsh::to_vec(&receipt).map_err(|err| zkVMError::Other(Box::new(err)))?;
         Ok((encoded, ProgramProvingReport::new(proving_time)))
     }
 
@@ -115,6 +116,14 @@ impl zkVM for EreRisc0 {
 
     fn sdk_version(&self) -> &'static str {
         SDK_VERSION
+    }
+}
+
+impl Drop for EreRisc0 {
+    fn drop(&mut self) {
+        if matches!(self.resource, ProverResourceType::Gpu) && !cfg!(feature = "metal") {
+            prove::bento::docker_compose_bento_down().unwrap_or_else(|err| eprintln!("{err}"))
+        }
     }
 }
 
@@ -171,7 +180,7 @@ mod prove_tests {
         input_builder.write(n);
         input_builder.write(a);
 
-        let zkvm = EreRisc0::new(program, ProverResourceType::Cpu);
+        let zkvm = EreRisc0::new(program, ProverResourceType::Cpu).unwrap();
 
         let (proof_bytes, _) = zkvm
             .prove(&input_builder)
@@ -191,9 +200,33 @@ mod prove_tests {
 
         let empty_input = Input::new();
 
-        let zkvm = EreRisc0::new(elf_bytes, ProverResourceType::Cpu);
+        let zkvm = EreRisc0::new(elf_bytes, ProverResourceType::Cpu).unwrap();
         let prove_result = zkvm.prove(&empty_input);
         assert!(prove_result.is_err());
+    }
+
+    #[test]
+    #[ignore = "Requires Nvidia GPU to run"]
+    #[cfg(not(feature = "metal"))]
+    fn test_prove_r0_dummy_input_bento() {
+        let program = get_compiled_test_r0_elf_for_prove().unwrap();
+
+        let mut input_builder = Input::new();
+        let n: u32 = 42;
+        let a: u16 = 42;
+        input_builder.write(n);
+        input_builder.write(a);
+
+        let zkvm = EreRisc0::new(program, ProverResourceType::Gpu).unwrap();
+
+        let (proof_bytes, _) = zkvm
+            .prove(&input_builder)
+            .unwrap_or_else(|err| panic!("Proving error in test: {err:?}"));
+
+        assert!(!proof_bytes.is_empty(), "Proof bytes should not be empty.");
+
+        let verify_results = zkvm.verify(&proof_bytes).is_ok();
+        assert!(verify_results);
     }
 }
 
@@ -230,7 +263,7 @@ mod execute_tests {
         input_builder.write(n);
         input_builder.write(a);
 
-        let zkvm = EreRisc0::new(program, ProverResourceType::Cpu);
+        let zkvm = EreRisc0::new(program, ProverResourceType::Cpu).unwrap();
 
         zkvm.execute(&input_builder)
             .unwrap_or_else(|err| panic!("Execution error: {err:?}"));
@@ -242,7 +275,7 @@ mod execute_tests {
 
         let empty_input = Input::new();
 
-        let zkvm = EreRisc0::new(program, ProverResourceType::Cpu);
+        let zkvm = EreRisc0::new(program, ProverResourceType::Cpu).unwrap();
         let result = zkvm.execute(&empty_input);
 
         assert!(

--- a/crates/ere-risc0/src/lib.rs
+++ b/crates/ere-risc0/src/lib.rs
@@ -206,8 +206,7 @@ mod prove_tests {
     }
 
     #[test]
-    #[ignore = "Requires Nvidia GPU to run"]
-    #[cfg(not(feature = "metal"))]
+    #[ignore = "Requires GPU to run"]
     fn test_prove_r0_dummy_input_bento() {
         let program = get_compiled_test_r0_elf_for_prove().unwrap();
 

--- a/crates/ere-risc0/src/prove.rs
+++ b/crates/ere-risc0/src/prove.rs
@@ -1,0 +1,2 @@
+pub mod bento;
+pub mod default;

--- a/crates/ere-risc0/src/prove/bento.rs
+++ b/crates/ere-risc0/src/prove/bento.rs
@@ -1,0 +1,233 @@
+use crate::{Risc0Program, SDK_VERSION};
+use bonsai_sdk::blocking::Client;
+use risc0_zkvm::{Receipt, VERSION, serde::to_vec};
+use std::{
+    env,
+    ffi::OsStr,
+    io::{self, Write},
+    process::{Command, Output, Stdio},
+    time::Duration,
+};
+use tempfile::tempdir;
+use zkvm_interface::{Input, InputItem, zkVMError};
+
+const URL: &str = "http://localhost:8081";
+const KEY: &str = "";
+
+// Copied and modified from https://github.com/risc0/risc0/blob/main/bento/crates/bento-client/src/bento_cli.rs.
+pub fn prove(program: &Risc0Program, inputs: &Input) -> Result<(Receipt, Duration), zkVMError> {
+    let client = Client::from_parts(URL.to_string(), KEY.to_string(), VERSION)
+        .map_err(|err| zkVMError::Other(err.into()))?;
+
+    // Serialize `inputs` in the same way `ExecutorEnv` does.
+    let mut input_bytes = Vec::new();
+    for input in inputs.iter() {
+        match input {
+            InputItem::Object(obj) => {
+                input_bytes.extend(bytemuck::cast_slice(&to_vec(obj).unwrap()));
+            }
+            InputItem::SerializedObject(bytes) => {
+                input_bytes.extend(bytes);
+            }
+            InputItem::Bytes(bytes) => {
+                input_bytes.extend((bytes.len() as u32).to_le_bytes());
+                input_bytes.extend(bytes);
+            }
+        }
+    }
+
+    client
+        .upload_img(&program.image_id.to_string(), program.elf.clone())
+        .map_err(|err| zkVMError::Other(err.into()))?;
+    let input_id = client
+        .upload_input(input_bytes)
+        .map_err(|err| zkVMError::Other(err.into()))?;
+
+    let now = std::time::Instant::now();
+
+    let session = client
+        .create_session(program.image_id.to_string(), input_id, vec![], false)
+        .map_err(|err| zkVMError::Other(err.into()))?;
+
+    loop {
+        let res = session
+            .status(&client)
+            .map_err(|err| zkVMError::Other(err.into()))?;
+
+        match res.status.as_ref() {
+            "RUNNING" => {
+                std::thread::sleep(Duration::from_millis(200));
+                continue;
+            }
+            "SUCCEEDED" => {
+                let receipt_bytes = client
+                    .receipt_download(&session)
+                    .map_err(|err| zkVMError::Other(err.into()))?;
+                break Ok((bincode::deserialize(&receipt_bytes).unwrap(), now.elapsed()));
+            }
+            _ => {
+                return Err(zkVMError::Other(
+                    format!("Unexpected proving status: {}", res.status).into(),
+                ));
+            }
+        }
+    }
+}
+
+fn cmd_output_checked(cmd: &mut Command) -> Result<Output, io::Error> {
+    let output = cmd.output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!("Failed to run `{cmd:?}`")));
+    }
+    Ok(output)
+}
+
+fn cmd_exec_checked(cmd: &mut Command) -> Result<(), io::Error> {
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!("Failed to run `{cmd:?}`")));
+    }
+    Ok(())
+}
+
+fn docker_image_exists(image: impl AsRef<OsStr>) -> Result<bool, io::Error> {
+    let output = cmd_output_checked(
+        Command::new("docker")
+            .args(["images", "--quiet"])
+            .arg(image),
+    )?;
+    // If image exists, image id will be printed hence stdout will be non-empty.
+    Ok(!output.stdout.is_empty())
+}
+
+fn docker_image_tag(src: impl AsRef<OsStr>, dst: impl AsRef<OsStr>) -> Result<(), io::Error> {
+    cmd_exec_checked(
+        Command::new("docker")
+            .args(["image", "tag"])
+            .arg(src)
+            .arg(dst),
+    )
+}
+
+pub fn build_bento_images() -> Result<(), io::Error> {
+    let agent_tag = format!("ere-risc0/agent:{SDK_VERSION}");
+    let rest_api_tag = format!("ere-risc0/rest_api:{SDK_VERSION}");
+
+    if docker_image_exists(&agent_tag)? && docker_image_exists(&rest_api_tag)? {
+        return Ok(());
+    }
+
+    let tempdir = tempdir()?;
+
+    cmd_exec_checked(
+        Command::new("git")
+            .args([
+                "clone",
+                "--single-branch",
+                "--branch",
+                &format!("v{SDK_VERSION}"),
+                "https://github.com/risc0/risc0.git",
+            ])
+            .arg(tempdir.path()),
+    )?;
+
+    cmd_exec_checked(
+        Command::new("docker")
+            .arg("compose")
+            .arg("--file")
+            .arg(tempdir.path().join("compose.yml"))
+            .arg("--env-file")
+            .arg(tempdir.path().join("bento/dockerfiles/sample.env"))
+            .arg("build"),
+    )?;
+
+    docker_image_tag("agent", agent_tag)?;
+    docker_image_tag("bento-rest_api", rest_api_tag)?;
+
+    Ok(())
+}
+
+const BENTO_COMPOSE_TEMPLATE: &str = include_str!("../../compose.yml");
+const BENTO_GPU_PROVER_AGENT_TEMPLATE: &str = include_str!("../../gpu_prover_agent.yml");
+
+fn bento_compose_file() -> String {
+    let cuda_visible_devices = env::var("CUDA_VISIBLE_DEVICES").unwrap_or_else(|_| "".to_string());
+    let cuda_visible_devices = cuda_visible_devices
+        .split(",")
+        .flat_map(|device_id| device_id.parse::<usize>().ok())
+        .collect::<Vec<_>>();
+
+    let mut compose: serde_yaml::Mapping = serde_yaml::from_str(BENTO_COMPOSE_TEMPLATE).unwrap();
+    let gpu_prover_agent: serde_yaml::Mapping =
+        serde_yaml::from_str(BENTO_GPU_PROVER_AGENT_TEMPLATE).unwrap();
+
+    if cuda_visible_devices.is_empty() {
+        let mut gpu_prover_agent = gpu_prover_agent.clone();
+        gpu_prover_agent.remove("deploy").unwrap();
+        compose["services"]
+            .as_mapping_mut()
+            .unwrap()
+            .insert("gpu_prove_agent0".into(), gpu_prover_agent.into());
+    } else {
+        for idx in cuda_visible_devices {
+            let mut gpu_prover_agent = gpu_prover_agent.clone();
+            gpu_prover_agent["deploy"]["resources"]["reservations"]["devices"][0]["device_ids"]
+                [0] = idx.to_string().into();
+            compose["services"].as_mapping_mut().unwrap().insert(
+                format!("gpu_prove_agent{idx}").into(),
+                gpu_prover_agent.into(),
+            );
+        }
+    }
+
+    serde_yaml::to_string(&compose).unwrap()
+}
+
+/// Execute `docker compose ... {command}` with `bento_compose_file()`.
+fn docker_compose_bento<I, S>(command: I) -> Result<(), io::Error>
+where
+    I: Clone + IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let rust_log = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+    let segment_size = env::var("SEGMENT_SIZE").unwrap_or_else(|_| "21".to_string());
+    let risc0_keccak_po2 = env::var("RISC0_KECCAK_PO2").unwrap_or_else(|_| "17".to_string());
+
+    let mut child = Command::new("docker")
+        .env("RUST_LOG", rust_log)
+        .env("RISC0_VERSION", SDK_VERSION)
+        .env("SEGMENT_SIZE", segment_size)
+        .env("RISC0_KECCAK_PO2", risc0_keccak_po2)
+        .args(["compose", "--file", "-"]) // Compose file from stdin.
+        .args(command.clone())
+        .stdin(Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(bento_compose_file().as_bytes())?;
+    drop(stdin);
+
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "Failed to spawn `docker compose --file - ${}`",
+            command
+                .into_iter()
+                .map(|s| s.as_ref().to_string_lossy().to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        )));
+    }
+
+    Ok(())
+}
+
+/// Execute `docker compose ... up --detach` with `bento_compose_file()`.
+pub fn docker_compose_bento_up() -> Result<(), io::Error> {
+    docker_compose_bento(["up", "--detach", "--wait"])
+}
+
+/// Execute `docker compose ... down --volumes` with `bento_compose_file()`.
+pub fn docker_compose_bento_down() -> Result<(), io::Error> {
+    docker_compose_bento(["down", "--volumes"])
+}

--- a/crates/ere-risc0/src/prove/bento.rs
+++ b/crates/ere-risc0/src/prove/bento.rs
@@ -123,7 +123,8 @@ pub fn build_bento_images() -> Result<(), io::Error> {
         Command::new("git")
             .args([
                 "clone",
-                "--single-branch",
+                "--depth",
+                "1",
                 "--branch",
                 &format!("v{SDK_VERSION}"),
                 "https://github.com/risc0/risc0.git",

--- a/crates/ere-risc0/src/prove/default.rs
+++ b/crates/ere-risc0/src/prove/default.rs
@@ -1,0 +1,19 @@
+use crate::{Risc0Program, serialize_inputs};
+use risc0_zkvm::{ExecutorEnv, ProverOpts, Receipt, default_prover};
+use std::time::Duration;
+use zkvm_interface::{Input, zkVMError};
+
+pub fn prove(program: &Risc0Program, inputs: &Input) -> Result<(Receipt, Duration), zkVMError> {
+    let prover = default_prover();
+    let mut env = ExecutorEnv::builder();
+    serialize_inputs(&mut env, inputs).map_err(|err| zkVMError::Other(err.into()))?;
+    let env = env.build().map_err(|err| zkVMError::Other(err.into()))?;
+
+    let now = std::time::Instant::now();
+    let prove_info = prover
+        .prove_with_opts(env, &program.elf, &ProverOpts::succinct())
+        .map_err(|err| zkVMError::Other(err.into()))?;
+    let proving_time = now.elapsed();
+
+    Ok((prove_info.receipt, proving_time))
+}

--- a/docker/risc0/Dockerfile
+++ b/docker/risc0/Dockerfile
@@ -5,6 +5,12 @@ FROM ${BASE_IMAGE_TAG}
 # Copy and run the Risc0 SDK installer script
 COPY scripts/sdk_installers/install_risc0_sdk.sh /tmp/install_risc0_sdk.sh
 
+# The install_risc0_sdk.sh script will respect these ENV variables.
+ENV RISC0_CLI_VERSION="2.3.1" \
+    RISC0_CPP_VERSION="2024.1.5" \
+    RISC0_R0VM_VERSION="2.3.1" \
+    RISC0_RUST_VERSION="1.88.0"
+
 # Run the script without version arguments to install latest
 RUN chmod +x /tmp/install_risc0_sdk.sh && /tmp/install_risc0_sdk.sh
 

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+ubuntu-drivers install
+
+if command -v nvcc &> /dev/null; then
+    echo "Cuda toolkit is already installed."
+else
+    # From https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#ubuntu.
+    wget https://developer.download.nvidia.com/compute/cuda/repos/$(. /etc/os-release; echo "${ID}${VERSION_ID}" | tr -d '.' | tr '[:upper:]' '[:lower:]')/$(uname -m)/cuda-keyring_1.1-1_all.deb
+    dpkg -i cuda-keyring_1.1-1_all.deb
+    rm cuda-keyring_1.1-1_all.deb
+    apt-get update
+    apt-get install -y cuda-toolkit
+
+    # From https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#environment-setup.
+    # Add to path.
+    cat >> ~/.bashrc <<EOF
+export PATH="$PATH:/usr/local/cuda/bin"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64"
+EOF
+fi
+
+if command -v nvidia-container-runtime &> /dev/null; then
+    echo "Nvidia container runtime is already installed."
+else
+    # From https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#with-apt-ubuntu-debian.
+    # Configure the production repository:
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+        && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+            | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+            | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+    # Install the NVIDIA Container Toolkit packages:
+    export NVIDIA_CONTAINER_TOOLKIT_VERSION=1.17.8-1
+    apt-get install -y \
+        nvidia-container-toolkit=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        nvidia-container-toolkit-base=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        libnvidia-container-tools=${NVIDIA_CONTAINER_TOOLKIT_VERSION} \
+        libnvidia-container1=${NVIDIA_CONTAINER_TOOLKIT_VERSION}
+
+    # From https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-docker.
+    # Configure the container runtime by using the `nvidia-ctk` command:
+    nvidia-ctk runtime configure --runtime=docker
+
+    # Restart docker
+    systemctl restart docker
+fi

--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+if command -v docker &> /dev/null; then
+    echo "Docker is already installed."
+else
+    # From https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository.
+    # Add Docker's official GPG key:
+    apt-get update
+    apt-get install ca-certificates curl
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    # Add the repository to Apt sources:
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" \
+        | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+
+# From https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user.
+# Use docker as a non-root user:
+grep -q docker /etc/group || groupadd docker
+usermod -aG docker $USER
+newgrp docker

--- a/scripts/sdk_installers/install_risc0_sdk.sh
+++ b/scripts/sdk_installers/install_risc0_sdk.sh
@@ -62,7 +62,17 @@ fi
 
 # Now that rzup is confirmed to be in PATH for this script, install the Risc0 toolchain
 echo "Running 'rzup install' to install/update Risc0 toolchain..."
-rzup install
+
+if [[ -n "$RISC0_CLI_VERSION" && -n "$RISC0_CPP_VERSION" && -n "$RISC0_R0VM_VERSION" && -n "$RISC0_RUST_VERSION" ]]; then
+    # If versions are specified, install each component by their version
+    rzup install cargo-risczero $RISC0_CLI_VERSION
+    rzup install cpp $RISC0_CPP_VERSION
+    rzup install r0vm $RISC0_R0VM_VERSION
+    rzup install rust $RISC0_RUST_VERSION
+else
+    # Otherwise just install all components with by their latest version
+    rzup install
+fi
 
 # Verify Risc0 installation
 echo "Verifying Risc0 installation..."


### PR DESCRIPTION
- Add script to install `cuda` for easier development
- Add script to install `docker` for easier development
- Remove `cuda` feature so we don't need feature flag to enable GPU proving
  - The building time is unaffected because the cuda GPU proving is using docker (image will be built when init the `EreRisc0`)
  - The `metal` feature remains optional because it increase the building time
- When the prover resource is GPU
  - `EreRisc0` builds the images if it doesn't exist (tagging with Risc0's SDK version), then use docker compose to spin up the proving services
  - Then send the image and input to the service for proving, and by interval (200ms) check if the proof is ready or not
  - When `EreRisc0` is dropped, it shuts down the services (if not properly dropped, the services get dangling.
  - In the future it'd be better to use channel to signal it successfully shut down the services, for caller to do gracefully shutdown.

Issues haven't figured out
- The first proving after the service is spin up will take some extra minutes, not sure what it's doing, or if there is any way to avoid this (just sleeping and waiting seems not working)