### PR TITLE
Resolves #49

### DIFF
--- a/.github/workflows/check_pico_image.yml
+++ b/.github/workflows/check_pico_image.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build_pico_image:
-    if: ${{ false }} # See issue #49
     name: Build Pico Docker Image
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-openvm-docker.yml
+++ b/.github/workflows/test-openvm-docker.yml
@@ -1,4 +1,4 @@
-name: Check Pico Docker Image
+name: Test OpenVM (Docker)
 
 on:
   push:
@@ -7,11 +7,10 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
 
 jobs:
-  build_pico_image:
-    name: Build Pico Docker Image
+  test-openvm-via-docker-build:
+    name: Build OpenVM Docker Image
     runs-on: ubuntu-latest
 
     steps:
@@ -21,16 +20,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build dependent Docker base image
+      - name: Build ere-base image
         run: |
           docker build \
-            --file docker/base/Dockerfile.base \
             --tag ere-base:latest \
-            .
+            --file docker/base/Dockerfile.base .
 
-      - name: Build Pico Docker image
+      - name: Build ere-builder-openvm image
         run: |
           docker build \
-            --file docker/pico/Dockerfile \
-            --tag ere-builder-pico-check:latest \
-            .
+            --tag ere-builder-openvm:latest \
+            --file docker/openvm/Dockerfile .

--- a/.github/workflows/test-pico-docker.yml
+++ b/.github/workflows/test-pico-docker.yml
@@ -1,4 +1,4 @@
-name: Check OpenVM Docker Image
+name: Test Pico (Docker)
 
 on:
   push:
@@ -7,11 +7,10 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
 
 jobs:
-  build_openvm_image:
-    name: Build OpenVM Docker Image
+  test-pico-via-docker-build:
+    name: Build Pico Docker Image
     runs-on: ubuntu-latest
 
     steps:
@@ -21,16 +20,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build dependent Docker base image
+      - name: Build ere-base image
         run: |
           docker build \
-            --file docker/base/Dockerfile.base \
             --tag ere-base:latest \
-            .
+            --file docker/base/Dockerfile.base .
 
-      - name: Build OpenVM Docker image
+      - name: Build ere-builder-pico image
         run: |
           docker build \
-            --file docker/openvm/Dockerfile \
-            --tag ere-builder-openvm-check:latest \
-            .
+            --tag ere-builder-pico:latest \
+            --file docker/pico/Dockerfile .

--- a/crates/zkvm-interface/src/input.rs
+++ b/crates/zkvm-interface/src/input.rs
@@ -48,7 +48,7 @@ impl Input {
     }
 
     /// Iterate over the items
-    pub fn iter(&self) -> std::slice::Iter<InputItem> {
+    pub fn iter(&self) -> std::slice::Iter<'_, InputItem> {
         self.items.iter()
     }
 }

--- a/docker/pico/Dockerfile
+++ b/docker/pico/Dockerfile
@@ -29,6 +29,6 @@ COPY . .
 
 # Run tests
 RUN echo "Running tests for ere-pico library..." && \
-    cargo test --release -p ere-pico --lib -- --color always
+    cargo "+${PICO_TOOLCHAIN_VERSION}" test --release -p ere-pico --lib -- --color always
 
 CMD ["/bin/bash"] 


### PR DESCRIPTION
- Fix warning from latest nightly rust.
- Fix `pico` docker test by isng the same rust version of `pico-sdk` so it compiles.
- Rename CI files of `pico` and `openvm` as `sp1` to be more consistent.

Resolves #49