### PR TITLE
zkvm-interface: allow dynamic dispatch

### DIFF
--- a/crates/ere-jolt/src/lib.rs
+++ b/crates/ere-jolt/src/lib.rs
@@ -104,11 +104,11 @@ impl zkVM for EreJolt {
         }
     }
 
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         NAME
     }
 
-    fn sdk_version() -> &'static str {
+    fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
 }

--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -165,11 +165,11 @@ impl zkVM for EreOpenVM {
             .map_err(zkVMError::from)
     }
 
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         NAME
     }
 
-    fn sdk_version() -> &'static str {
+    fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
 }

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -128,11 +128,11 @@ impl zkVM for ErePico {
         todo!("Verification method missing from sdk")
     }
 
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         NAME
     }
 
-    fn sdk_version() -> &'static str {
+    fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
 }

--- a/crates/ere-risczero/src/lib.rs
+++ b/crates/ere-risczero/src/lib.rs
@@ -124,11 +124,11 @@ impl zkVM for EreRisc0 {
             .map_err(|err| zkVMError::Other(Box::new(err)))
     }
 
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         NAME
     }
 
-    fn sdk_version() -> &'static str {
+    fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
 }

--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -215,11 +215,11 @@ impl zkVM for EreSP1 {
         client.verify(&proof, &self.vk).map_err(zkVMError::from)
     }
 
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         NAME
     }
 
-    fn sdk_version() -> &'static str {
+    fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
 }

--- a/crates/ere-zisk/src/lib.rs
+++ b/crates/ere-zisk/src/lib.rs
@@ -248,11 +248,11 @@ impl zkVM for EreZisk {
         Ok(())
     }
 
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         NAME
     }
 
-    fn sdk_version() -> &'static str {
+    fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
 }

--- a/crates/zkvm-interface/src/lib.rs
+++ b/crates/zkvm-interface/src/lib.rs
@@ -83,8 +83,8 @@ pub trait zkVM {
     fn verify(&self, proof: &[u8]) -> Result<(), zkVMError>;
 
     /// Returns the name of the zkVM
-    fn name() -> &'static str;
+    fn name(&self) -> &'static str;
 
     /// Returns the version of the zkVM SDK (e.g. 0.1.0)
-    fn sdk_version() -> &'static str;
+    fn sdk_version(&self) -> &'static str;
 }


### PR DESCRIPTION
This PR addresses a minor oversight from my last change, adding name and SDK versioning support to the trait. 

The current implementation prevents the use of the trait via dynamic dispatching, which blocks generalization in the workflow repo (https://github.com/eth-act/zkevm-benchmark-workload/pull/108).

I'm not fully convinced on why the Rust compiler can only have methods in the trait to allow for dynamic dispatching, I guess it is related to the way the vtable construction is done. Trait functions could have a fixed address in the vtable and resolve it that way? In any case, not much I can do -- the Rust compiler was quite clear in the message on not allowing non-methods for dynamic dispatch support in traits.