### PR TITLE
InputItem: Support extra traits

### DIFF
--- a/crates/ere-risczero/Cargo.toml
+++ b/crates/ere-risczero/Cargo.toml
@@ -16,7 +16,7 @@ hex = "*"
 tempfile = "3.3"
 serde_json = "1.0"
 thiserror = "2"
-serde = { version = "1.0.219", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive", "rc"] }
 
 [build-dependencies]
 build-utils = { workspace = true }

--- a/crates/ere-risczero/Cargo.toml
+++ b/crates/ere-risczero/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 zkvm-interface = { workspace = true }
 anyhow = "1.0"                                               #TODO: remove only needed in tests
 toml = "0.8"
-risc0-zkvm = { version = "^2.2.0", features = ["unstable"] }
+risc0-zkvm = { version = "^2.3.0", features = ["unstable"] }
 borsh = "1.5.7"
 hex = "*"
 

--- a/crates/zkvm-interface/src/input.rs
+++ b/crates/zkvm-interface/src/input.rs
@@ -7,9 +7,9 @@ use serde::Serialize;
 #[derive(Clone)]
 pub enum InputItem {
     /// A serializable object stored as a trait object
-    Object(Arc<dyn ErasedSerialize + Send + Sync>),
+    Object(Arc<Box<dyn ErasedSerialize + Send + Sync>>),
     /// Pre-serialized bytes (e.g., from bincode)
-    Bytes(Arc<Vec<u8>>),
+    Bytes(Vec<u8>),
 }
 
 impl Debug for InputItem {
@@ -42,12 +42,13 @@ impl Input {
 
     /// Write a serializable value as a trait object
     pub fn write<T: Serialize + Send + Sync + 'static>(&mut self, value: T) {
-        self.items.push(InputItem::Object(Arc::new(value)));
+        self.items
+            .push(InputItem::Object(Arc::new(Box::new(value))));
     }
 
     /// Write pre-serialized bytes directly
     pub fn write_bytes(&mut self, bytes: Vec<u8>) {
-        self.items.push(InputItem::Bytes(Arc::new(bytes)));
+        self.items.push(InputItem::Bytes(bytes));
     }
 
     /// Get the number of items stored

--- a/tests/risczero/compile/project_structure_build/Cargo.toml
+++ b/tests/risczero/compile/project_structure_build/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [build-dependencies]
-risc0-build = { version = "^2.1.1" }
+risc0-build = { version = "^2.3.0" }
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/tests/risczero/compile/project_structure_build/guest/Cargo.toml
+++ b/tests/risczero/compile/project_structure_build/guest/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "^2.0.2", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "^2.3.0", default-features = false, features = [
+    'std',
+] }


### PR DESCRIPTION
This PR makes some changes to `InputItem` to support: `Debug`, `Sync`, `Send`, and `Clone`.