### PR TITLE
Add `ere-cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "clap",
+ "ere-jolt",
+ "ere-nexus",
+ "ere-openvm",
+ "ere-pico",
+ "ere-risc0",
+ "ere-sp1",
+ "ere-zisk",
+ "serde",
+ "zkvm-interface",
+]
+
+[[package]]
 name = "ere-jolt"
 version = "0.1.0"
 dependencies = [
@@ -11129,6 +11147,7 @@ dependencies = [
  "anyhow",
  "auto_impl",
  "bincode",
+ "clap",
  "erased-serde",
  "humantime-serde",
  "indexmap 2.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ members = [
     "crates/ere-zisk",
     # zkVM interface
     "crates/zkvm-interface",
-
+    # CLI
+    "crates/ere-cli",
     # Guest compilers
     "docker/sp1",
     "docker/risc0",
@@ -30,7 +31,7 @@ license = "MIT OR Apache-2.0"
 tracing = "0.1.41"
 tempfile = "3.3"
 toml = "0.8"
-clap = { version = "4.5.41", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 hex = "0.4.3"
 

--- a/crates/ere-cli/Cargo.toml
+++ b/crates/ere-cli/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ere-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+bincode = "1.3"
+serde = { version = "1.0", features = ["derive"] }
+
+ere-jolt = { workspace = true, optional = true }
+ere-nexus = { workspace = true, optional = true }
+ere-openvm = { workspace = true, optional = true }
+ere-pico = { workspace = true, optional = true }
+ere-risc0 = { workspace = true, optional = true }
+ere-sp1 = { workspace = true, optional = true }
+ere-zisk = { workspace = true, optional = true }
+zkvm-interface = { workspace = true, features = ["clap"] }
+
+[dev-dependencies]
+
+[lints]
+workspace = true
+
+[features]
+default = []
+jolt = ["dep:ere-jolt"]
+nexus = ["dep:ere-nexus"]
+openvm = ["dep:ere-openvm"]
+pico = ["dep:ere-pico"]
+risc0 = ["dep:ere-risc0"]
+sp1 = ["dep:ere-sp1"]
+zisk = ["dep:ere-zisk"]

--- a/crates/ere-cli/src/main.rs
+++ b/crates/ere-cli/src/main.rs
@@ -1,0 +1,213 @@
+use anyhow::{Context, Error};
+use clap::{Parser, Subcommand};
+use std::{fs, path::PathBuf};
+use zkvm_interface::{Compiler, ProverResourceType, zkVM};
+
+mod serde;
+
+// Compile-time check to ensure exactly one backend feature is enabled
+const _: () = {
+    assert!(
+        (cfg!(feature = "jolt") as u8
+            + cfg!(feature = "nexus") as u8
+            + cfg!(feature = "openvm") as u8
+            + cfg!(feature = "pico") as u8
+            + cfg!(feature = "risc0") as u8
+            + cfg!(feature = "sp1") as u8
+            + cfg!(feature = "zisk") as u8)
+            == 1,
+        "Exactly one zkVM backend feature must be enabled"
+    );
+};
+
+#[derive(Parser)]
+#[command(author, version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Compile a guest program
+    Compile {
+        /// Path to the base directory (workspace root)
+        #[arg(long)]
+        mount_directory: PathBuf,
+        /// Relative path from `mount_directory` to the guest program
+        #[arg(long)]
+        guest_relative: PathBuf,
+        /// Path where the compiled program will be written
+        #[arg(long)]
+        program_path: PathBuf,
+    },
+    /// Execute a compiled program
+    Execute {
+        /// Path to the compiled program
+        #[arg(long)]
+        program_path: PathBuf,
+        /// Path to the serialized input bytes file
+        #[arg(long)]
+        input_path: PathBuf,
+        /// Path where the execution report will be written
+        #[arg(long)]
+        report_path: PathBuf,
+        // Prover resource type
+        #[command(subcommand)]
+        resource: ProverResourceType,
+    },
+    /// Prove execution of a compiled program
+    Prove {
+        /// Path to the compiled program
+        #[arg(long)]
+        program_path: PathBuf,
+        /// Path to the serialized input bytes file
+        #[arg(long)]
+        input_path: PathBuf,
+        /// Path where the proof will be written
+        #[arg(long)]
+        proof_path: PathBuf,
+        /// Path where the report will be written
+        #[arg(long)]
+        report_path: PathBuf,
+        // Prover resource type
+        #[command(subcommand)]
+        resource: ProverResourceType,
+    },
+    /// Verify execution of a compiled program
+    Verify {
+        /// Path to the compiled program
+        #[arg(long)]
+        program_path: PathBuf,
+        /// Path to the proof
+        #[arg(long)]
+        proof_path: PathBuf,
+    },
+}
+
+fn main() -> Result<(), Error> {
+    let args = Cli::parse();
+
+    match args.command {
+        Commands::Compile {
+            mount_directory,
+            guest_relative,
+            program_path,
+        } => compile(mount_directory, guest_relative, program_path),
+        Commands::Prove {
+            program_path,
+            input_path,
+            proof_path,
+            report_path,
+            resource,
+        } => prove(program_path, resource, input_path, proof_path, report_path),
+        Commands::Execute {
+            program_path,
+            input_path,
+            report_path,
+            resource,
+        } => execute(program_path, resource, input_path, report_path),
+        Commands::Verify {
+            program_path,
+            proof_path,
+        } => verify(program_path, proof_path),
+    }
+}
+
+fn compile(
+    mount_directory: PathBuf,
+    guest_relative: PathBuf,
+    program_path: PathBuf,
+) -> Result<(), Error> {
+    #[cfg(feature = "jolt")]
+    let program = ere_jolt::JOLT_TARGET::compile(&mount_directory, &guest_relative);
+
+    #[cfg(feature = "nexus")]
+    let program = ere_nexus::NEXUS_TARGET::compile(&mount_directory, &guest_relative);
+
+    #[cfg(feature = "openvm")]
+    let program = ere_openvm::OPENVM_TARGET::compile(&mount_directory, &guest_relative);
+
+    #[cfg(feature = "pico")]
+    let program = ere_pico::PICO_TARGET::compile(&mount_directory, &guest_relative);
+
+    #[cfg(feature = "risc0")]
+    let program = ere_risc0::RV32_IM_RISC0_ZKVM_ELF::compile(&mount_directory, &guest_relative);
+
+    #[cfg(feature = "sp1")]
+    let program = ere_sp1::RV32_IM_SUCCINCT_ZKVM_ELF::compile(&mount_directory, &guest_relative);
+
+    #[cfg(feature = "zisk")]
+    let program = ere_zisk::RV64_IMA_ZISK_ZKVM_ELF::compile(&mount_directory, &guest_relative);
+
+    serde::write(
+        &program_path,
+        &program.with_context(|| "Failed to compile program")?,
+        "program",
+    )
+}
+
+fn prove(
+    program_path: PathBuf,
+    resource: ProverResourceType,
+    input_path: PathBuf,
+    proof_path: PathBuf,
+    report_path: PathBuf,
+) -> Result<(), Error> {
+    let zkvm = construct_zkvm(program_path, resource)?;
+    let input = serde::read_input(&input_path)?;
+    let (proof, report) = zkvm.prove(&input).with_context(|| "Failed to prove")?;
+    fs::write(&proof_path, proof)
+        .with_context(|| format!("Failed to write proof to {}", proof_path.display()))?;
+    serde::write(&report_path, &report, "report")?;
+    Ok(())
+}
+
+fn execute(
+    program_path: PathBuf,
+    resource: ProverResourceType,
+    input_path: PathBuf,
+    report_path: PathBuf,
+) -> Result<(), Error> {
+    let zkvm = construct_zkvm(program_path, resource)?;
+    let input = serde::read_input(&input_path)?;
+    let report = zkvm.execute(&input).with_context(|| "Failed to execute")?;
+    serde::write(&report_path, &report, "report")?;
+    Ok(())
+}
+
+fn verify(program_path: PathBuf, proof_path: PathBuf) -> Result<(), Error> {
+    let zkvm = construct_zkvm(program_path, ProverResourceType::default())?;
+    let proof = fs::read(&proof_path)
+        .with_context(|| format!("Failed to read proof from {}", proof_path.display()))?;
+    zkvm.verify(&proof)
+        .with_context(|| "Failed to verify proof")?;
+    Ok(())
+}
+
+fn construct_zkvm(program_path: PathBuf, resource: ProverResourceType) -> Result<impl zkVM, Error> {
+    let program = serde::read(&program_path, "program")?;
+
+    #[cfg(feature = "jolt")]
+    let zkvm = ere_jolt::EreJolt::new(program, resource);
+
+    #[cfg(feature = "nexus")]
+    let zkvm = Ok::<_, Error>(ere_nexus::EreNexus::new(program, resource));
+
+    #[cfg(feature = "openvm")]
+    let zkvm = ere_openvm::EreOpenVM::new(program, resource);
+
+    #[cfg(feature = "pico")]
+    let zkvm = Ok::<_, Error>(ere_pico::ErePico::new(program, resource));
+
+    #[cfg(feature = "risc0")]
+    let zkvm = Ok::<_, Error>(ere_risc0::EreRisc0::new(program, resource));
+
+    #[cfg(feature = "sp1")]
+    let zkvm = Ok::<_, Error>(ere_sp1::EreSP1::new(program, resource));
+
+    #[cfg(feature = "zisk")]
+    let zkvm = Ok::<_, Error>(ere_zisk::EreZisk::new(program, resource));
+
+    zkvm.with_context(|| "Failed to instantiate zkVM")
+}

--- a/crates/ere-cli/src/serde.rs
+++ b/crates/ere-cli/src/serde.rs
@@ -1,0 +1,28 @@
+use anyhow::{Context, Error};
+use serde::{Serialize, de::DeserializeOwned};
+use std::{fs, path::Path};
+use zkvm_interface::{Input, InputItem};
+
+/// Read `Input` from `input_path`.
+///
+/// `Input` is assumed to be serialized into sequence of bytes, and each bytes
+/// in the sequence is serialized in the specific way the zkvm does.
+pub fn read_input(input_path: &Path) -> Result<Input, Error> {
+    read::<Vec<Vec<u8>>>(input_path, "input")
+        .map(|seq| Input::from(Vec::from_iter(seq.into_iter().map(InputItem::Bytes))))
+}
+
+/// Serialize `value` with [`bincode`] and write to `path`.
+pub fn write<P: Serialize>(path: &Path, value: &P, identifier: &str) -> Result<(), Error> {
+    let bytes =
+        bincode::serialize(value).with_context(|| format!("Failed to serialize {identifier}"))?;
+    fs::write(path, &bytes)
+        .with_context(|| format!("Failed to write {identifier} at {}", path.display()))
+}
+
+/// Read from `path` and deserialize with [`bincode`].
+pub fn read<P: DeserializeOwned>(path: &Path, identifier: &str) -> Result<P, Error> {
+    let bytes = fs::read(path)
+        .with_context(|| format!("Failed to read {identifier} at {}", path.display()))?;
+    bincode::deserialize(&bytes).with_context(|| "Failed to deserialize {identifier}")
+}

--- a/crates/zkvm-interface/Cargo.toml
+++ b/crates/zkvm-interface/Cargo.toml
@@ -14,9 +14,14 @@ thiserror = "2"
 auto_impl = "1.0"
 erased-serde = "0.4.6"
 humantime-serde = "1.1"
+clap = { version = "4.5", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1"
 
 [lints]
 workspace = true
+
+[features]
+default = []
+clap = ["dep:clap"]

--- a/crates/zkvm-interface/src/input.rs
+++ b/crates/zkvm-interface/src/input.rs
@@ -66,6 +66,12 @@ impl Input {
     }
 }
 
+impl From<Vec<InputItem>> for Input {
+    fn from(items: Vec<InputItem>) -> Self {
+        Self { items }
+    }
+}
+
 // Optional: Implement methods to work with the enum
 impl InputItem {
     /// Serialize this item to bytes using the specified serializer

--- a/crates/zkvm-interface/src/lib.rs
+++ b/crates/zkvm-interface/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::{Serialize, de::DeserializeOwned};
 use std::path::Path;
 use thiserror::Error;
 
@@ -14,7 +15,7 @@ pub use network::NetworkProverConfig;
 /// Compiler trait for compiling programs into an opaque sequence of bytes.
 pub trait Compiler {
     type Error: std::error::Error + Send + Sync + 'static;
-    type Program: Clone + Send + Sync;
+    type Program: Clone + Send + Sync + Serialize + DeserializeOwned;
 
     /// Compiles the program and returns the program
     ///
@@ -27,6 +28,7 @@ pub trait Compiler {
 
 /// ResourceType specifies what resource will be used to create the proofs.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "clap", derive(clap::Subcommand))]
 pub enum ProverResourceType {
     #[default]
     Cpu,

--- a/crates/zkvm-interface/src/network.rs
+++ b/crates/zkvm-interface/src/network.rs
@@ -2,10 +2,13 @@ use serde::{Deserialize, Serialize};
 
 /// Configuration for network-based proving
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct NetworkProverConfig {
+    #[cfg_attr(feature = "clap", arg(long))]
     /// The endpoint URL of the prover network service
     pub endpoint: String,
 
+    #[cfg_attr(feature = "clap", arg(long))]
     /// Optional API key for authentication
     pub api_key: Option<String>,
 }


### PR DESCRIPTION
First part of #66 

Implement `ere-cli` which provides a cli to do `compile`, `execute`, `prove` and `verify` of specific zkVM implementation selected by feature flag. The reason to not include all `zkvm` is due to compliation time, in case one only wants to use single zkvm, not sure if this is the best approach so open to disuccsion.

The imagined usage of the cli is with `ere-dockerized`, which handles the de/serialization of program, input, etc... It seems not very easy to run it by hand (due to serialization)
