### PR TITLE
Refactor `ere-zisk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,7 +2437,6 @@ dependencies = [
  "bincode",
  "blake3",
  "build-utils",
- "lib-c",
  "serde",
  "tempfile",
  "thiserror 2.0.12",
@@ -3894,11 +3893,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "lib-c"
-version = "0.9.0"
-source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.9.0#efbcdd4dddb39cf410d496358d01ee133a484780"
 
 [[package]]
 name = "libc"

--- a/crates/ere-zisk/Cargo.toml
+++ b/crates/ere-zisk/Cargo.toml
@@ -15,10 +15,6 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 blake3 = "1.3.1"
 
-[dev-dependencies]
-# Adding this to make sure `lib-c/build.rs` is ran before testing.
-lib-c = { git = "https://github.com/0xPolygonHermez/zisk.git", tag = "v0.9.0" }
-
 [build-dependencies]
 build-utils = { workspace = true }
 

--- a/scripts/sdk_installers/install_zisk_sdk.sh
+++ b/scripts/sdk_installers/install_zisk_sdk.sh
@@ -75,3 +75,11 @@ else
     echo "Error: 'cargo-zisk-gpu --version' failed." >&2
     exit 1
 fi
+
+# Step 4: Make sure `lib-c`'s build script is ran.
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+cargo init . --name build-lib-c
+cargo add lib-c --git https://github.com/0xPolygonHermez/zisk.git --tag "v${ZISK_VERSION}"
+cargo build
+rm -rf "$TEMP_DIR"


### PR DESCRIPTION
Remove `lib-c` `dev-dependencies` and make sure `lib-c` build script is ran during SDK installation, so latter the CI doesn't need to install `nasm` when running cargo clippy.
