### PR TITLE
Fix `ere-dockerized` SP1 GPU prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "ere-sp1",
  "ere-zisk",
  "serde",
+ "tracing-subscriber 0.3.19",
  "zkvm-interface",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tempfile = "3.20.0"
 thiserror = "2.0.12"
 toml = "0.8.23"
 tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 
 # Jolt dependencies
 ark-serialize = "0.5.0"

--- a/crates/ere-cli/Cargo.toml
+++ b/crates/ere-cli/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 bincode.workspace = true
 clap.workspace = true
 serde = { workspace = true, features = ["derive"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # Local dependencies
 ere-jolt = { workspace = true, optional = true }

--- a/crates/ere-cli/src/main.rs
+++ b/crates/ere-cli/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Error};
 use clap::{Parser, Subcommand};
 use std::{fs, path::PathBuf};
+use tracing_subscriber::EnvFilter;
 use zkvm_interface::{Compiler, ProverResourceType, zkVM};
 
 mod serde;
@@ -85,6 +86,10 @@ enum Commands {
 }
 
 fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
     let args = Cli::parse();
 
     match args.command {

--- a/crates/ere-cli/src/main.rs
+++ b/crates/ere-cli/src/main.rs
@@ -52,9 +52,6 @@ enum Commands {
         /// Path where the execution report will be written
         #[arg(long)]
         report_path: PathBuf,
-        // Prover resource type
-        #[command(subcommand)]
-        resource: ProverResourceType,
     },
     /// Prove execution of a compiled program
     Prove {
@@ -97,6 +94,11 @@ fn main() -> Result<(), Error> {
             guest_path,
             program_path,
         } => compile(guest_path, program_path),
+        Commands::Execute {
+            program_path,
+            input_path,
+            report_path,
+        } => execute(program_path, input_path, report_path),
         Commands::Prove {
             program_path,
             input_path,
@@ -104,12 +106,6 @@ fn main() -> Result<(), Error> {
             report_path,
             resource,
         } => prove(program_path, resource, input_path, proof_path, report_path),
-        Commands::Execute {
-            program_path,
-            input_path,
-            report_path,
-            resource,
-        } => execute(program_path, resource, input_path, report_path),
         Commands::Verify {
             program_path,
             proof_path,
@@ -162,13 +158,8 @@ fn prove(
     Ok(())
 }
 
-fn execute(
-    program_path: PathBuf,
-    resource: ProverResourceType,
-    input_path: PathBuf,
-    report_path: PathBuf,
-) -> Result<(), Error> {
-    let zkvm = construct_zkvm(program_path, resource)?;
+fn execute(program_path: PathBuf, input_path: PathBuf, report_path: PathBuf) -> Result<(), Error> {
+    let zkvm = construct_zkvm(program_path, ProverResourceType::Cpu)?;
     let input = serde::read_input(&input_path)?;
     let report = zkvm.execute(&input).with_context(|| "Failed to execute")?;
     serde::write(&report_path, &report, "report")?;
@@ -176,7 +167,7 @@ fn execute(
 }
 
 fn verify(program_path: PathBuf, proof_path: PathBuf) -> Result<(), Error> {
-    let zkvm = construct_zkvm(program_path, ProverResourceType::default())?;
+    let zkvm = construct_zkvm(program_path, ProverResourceType::Cpu)?;
     let proof = fs::read(&proof_path)
         .with_context(|| format!("Failed to read proof from {}", proof_path.display()))?;
     zkvm.verify(&proof)

--- a/crates/ere-dockerized/src/docker.rs
+++ b/crates/ere-dockerized/src/docker.rs
@@ -1,5 +1,6 @@
 use crate::error::CommonError;
 use std::{
+    env,
     fmt::{self, Display, Formatter},
     io,
     path::Path,
@@ -113,6 +114,16 @@ impl DockerRunCmd {
 
     pub fn gpus(mut self, devices: impl AsRef<str>) -> Self {
         self.options.push(CmdOption::new("gpus", devices));
+        self
+    }
+
+    /// Inherit environment variable `key` if it's set and valid.
+    pub fn inherit_env(mut self, key: impl AsRef<str>) -> Self {
+        let key = key.as_ref();
+        if let Ok(val) = env::var(key) {
+            self.options
+                .push(CmdOption::new("env", format!("{key}={val}")));
+        }
         self
     }
 

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -354,7 +354,15 @@ impl zkVM for EreDockerizedzkVM {
             .volume(tempdir.path(), "/workspace");
 
         if matches!(self.resource, ProverResourceType::Gpu) {
-            cmd = cmd.gpus("all")
+            cmd = cmd.gpus("all");
+
+            // SP1's GPU proving requires Docker to start GPU prover service, to
+            // give the client access to the prover service, we need to use the
+            // host networking driver.
+            match self.zkvm {
+                ErezkVM::SP1 | ErezkVM::Risc0 => cmd = cmd.mount_docker_socket().network("host"),
+                _ => {}
+            }
         }
 
         cmd.exec(

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -239,6 +239,7 @@ impl Compiler for EreDockerizedCompiler {
 
         DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
+            .inherit_env("RUST_LOG")
             .volume(&self.mount_directory, "/guest")
             .volume(tempdir.path(), "/guest-output")
             .exec([
@@ -306,6 +307,7 @@ impl zkVM for EreDockerizedzkVM {
 
         let mut cmd = DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
+            .inherit_env("RUST_LOG")
             .volume(tempdir.path(), "/workspace");
 
         if matches!(self.resource, ProverResourceType::Gpu) {
@@ -357,6 +359,7 @@ impl zkVM for EreDockerizedzkVM {
 
         let mut cmd = DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
+            .inherit_env("RUST_LOG")
             .volume(tempdir.path(), "/workspace");
 
         if matches!(self.resource, ProverResourceType::Gpu) {
@@ -407,6 +410,7 @@ impl zkVM for EreDockerizedzkVM {
 
         DockerRunCmd::new(self.zkvm.cli_zkvm_tag(CRATE_VERSION))
             .rm()
+            .inherit_env("RUST_LOG")
             .volume(tempdir.path(), "/workspace")
             .exec([
                 "verify",

--- a/docker/sp1/Dockerfile
+++ b/docker/sp1/Dockerfile
@@ -27,6 +27,8 @@ ENV PATH="${SP1UP_HOME}/bin:${SP1_HOME}/bin:$PATH"
 # Verify SP1 installation (optional here, as script does it, but good for sanity)
 RUN cargo prove --version
 
+COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
+
 CMD ["/bin/bash"]
 
 # TODO:  Maybe we use root to install it in ere_user and then switch back to ere_user for security


### PR DESCRIPTION
This PR mainly fixes `ere-dockerized` SP1 GPU prover, also does:

- Add `tracing_subscriber` with `EnvFilter` in `ere-cli`
- Inherit `RUST_LOG` from `ere-dockerized` to `ere-cli`
- Always use CPU to `execute` in `ere-cli`
- Add `docker` cli into SP1's base image, add flags to `docker run` to enable SP1 GPU prover service (enables Docker-out-of-Docker and host network).
