### PR TITLE
Cleanup some todos in SP1 dockerfile

### DIFF
--- a/docker/sp1/Dockerfile
+++ b/docker/sp1/Dockerfile
@@ -5,28 +5,25 @@ FROM ${BASE_IMAGE_TAG}
 ARG USERNAME=ere_user
 
 # Copy the SP1 SDK installer script
-COPY scripts/sdk_installers/install_sp1_sdk.sh /tmp/install_sp1_sdk.sh
-RUN chmod +x /tmp/install_sp1_sdk.sh
+COPY --chmod=+x scripts/sdk_installers/install_sp1_sdk.sh /tmp/install_sp1_sdk.sh
 
-# TODO: Check the sp1up script to see if most of the below path configs are needed
 # Define where SP1 SDK will be installed within the image.
 # The install_sp1_sdk.sh script will respect these ENV variables.
-# TODO: we are hardcoding /root which may not work for other users
-ENV SP1UP_HOME="/root/.sp1up" \
-    SP1UP_SDK_INSTALL_VERSION="v5.1.0" \
-    SP1_HOME="/root/.sp1"
+ENV SP1_DIR="/root/.sp1" \
+    SP1_VERSION="v5.1.0"
 
 # Run the SP1 SDK installation script
-# It will use the SP1UP_HOME and SP1_HOME defined above.
-RUN /tmp/install_sp1_sdk.sh && rm /tmp/install_sp1_sdk.sh # Clean up script
+# It will use the SP1_DIR and SP1_VERSION defined above.
+RUN /tmp/install_sp1_sdk.sh && rm /tmp/install_sp1_sdk.sh
 
 # Update the image's persistent PATH to include SP1 binaries.
-# This uses the SP1UP_HOME and SP1_HOME defined above.
-ENV PATH="${SP1UP_HOME}/bin:${SP1_HOME}/bin:$PATH"
+# This uses the SP1_DIR defined above.
+ENV PATH="${SP1_DIR}/bin:$PATH"
 
 # Verify SP1 installation (optional here, as script does it, but good for sanity)
 RUN cargo prove --version
 
+# Add Docker CLI
 COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
 
 CMD ["/bin/bash"]

--- a/scripts/sdk_installers/install_sp1_sdk.sh
+++ b/scripts/sdk_installers/install_sp1_sdk.sh
@@ -14,29 +14,27 @@ if ! command -v bash &> /dev/null; then # sp1up script uses bash
 fi
 
 # Define default homes if not set, useful for Docker context
-DEFAULT_SP1UP_HOME="${HOME}/.sp1up"
-DEFAULT_SP1_HOME="${HOME}/.sp1"
+DEFAULT_SP1_DIR="${HOME}/.sp1"
 
 # Use existing ENV var or default. Docker ENV will make these available.
 # For local use, user might need to add these to their .bashrc/.zshrc
-export SP1UP_HOME="${SP1UP_HOME:-${DEFAULT_SP1UP_HOME}}"
-export SP1_HOME="${SP1_HOME:-${DEFAULT_SP1_HOME}}"
+export SP1_DIR="${SP1_DIR:-${DEFAULT_SP1_DIR}}"
 
 # Run sp1up installer script
-curl -L https://sp1up.succinct.xyz | bash -s -- --yes 
+curl -L https://sp1up.succinct.xyz | bash
 
 # Add sp1up and sp1 binaries to PATH for this script's execution context
 # and for subsequent commands if this script is sourced.
-export PATH="${SP1UP_HOME}/bin:${SP1_HOME}/bin:$PATH"
+export PATH="${SP1_DIR}/bin:$PATH"
 
-export SDK_VERSION="${SP1UP_SDK_INSTALL_VERSION:-latest}"
+export SP1_VERSION="${SP1_VERSION:-latest}"
 
 # Run sp1up to install/update the toolchain
 if ! command -v sp1up &> /dev/null; then
     echo "Error: sp1up command not found after installation script. Check PATH or installation." >&2
     exit 1
 fi
-sp1up -v ${SDK_VERSION} # Installs the toolchain and cargo-prove
+sp1up -v ${SP1_VERSION} # Installs the toolchain and cargo-prove
 
 echo "Verifying SP1 installation..."
 if ! command -v cargo &> /dev/null; then
@@ -49,7 +47,6 @@ rustup toolchain list | grep succinct || (echo "Error: SP1 Toolchain (succinct) 
 
 echo "Succinct SP1 Toolchain installation successful."
 echo "If running locally (not in Docker), to make SP1 commands available in your current shell or new shells, ensure the following are in your shell profile (e.g., ~/.bashrc, ~/.zshrc):"
-echo "  export SP1UP_HOME=\"${SP1UP_HOME}\""
-echo "  export SP1_HOME=\"${SP1_HOME}\""
-echo "  export PATH=\"${SP1UP_HOME}/bin:${SP1_HOME}/bin:\$PATH\""
-echo "Then source your profile or open a new terminal." 
+echo "  export SP1_DIR=\"${SP1_DIR}\""
+echo "  export PATH=\"${SP1_DIR}/bin:\$PATH\""
+echo "Then source your profile or open a new terminal."


### PR DESCRIPTION
Also noticed that SP1 doesn't really use the env `SP1_DIR` in their `cargo-prove` CLI, when it installs the toolchain [it always install to `$HOME/.sp1`](https://github.com/succinctlabs/sp1/blob/v5.1.0/crates/cli/src/commands/install_toolchain.rs#L61).

So not sure if we should keep the `SP1_DIR` a argument or not.