### PR TITLE
Add `InputItem::SerializedObject`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,7 @@ dependencies = [
  "bincode",
  "build-utils",
  "bytemuck",
+ "ere-cli",
  "risc0-zkvm",
  "serde",
  "tempfile",
@@ -2387,6 +2388,7 @@ dependencies = [
  "bincode",
  "build-utils",
  "pico-sdk",
+ "pico-vm",
  "thiserror 2.0.12",
  "zkvm-interface",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", ta
 openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.2.0", default-features = false }
 
 # Pico dependencies
+pico-vm = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.4" }
 pico-sdk = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.4" }
 
 # Risc0 dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ sp1-sdk = "5.1.0"
 # Local dependencies
 zkvm-interface = { path = "crates/zkvm-interface" }
 build-utils = { path = "crates/build-utils" }
-ere-cli = { path = "crates/ere-cli" }
+ere-cli = { path = "crates/ere-cli", default-features = false }
 ere-dockerized = { path = "crates/ere-dockerized" }
 ere-jolt = { path = "crates/ere-jolt" }
 ere-nexus = { path = "crates/ere-nexus" }

--- a/crates/ere-cli/Cargo.toml
+++ b/crates/ere-cli/Cargo.toml
@@ -8,9 +8,9 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 bincode.workspace = true
-clap.workspace = true
+clap = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 
 # Local dependencies
 ere-jolt = { workspace = true, optional = true }
@@ -29,6 +29,7 @@ workspace = true
 
 [features]
 default = []
+cli = ["dep:clap", "dep:tracing-subscriber"]
 jolt = ["dep:ere-jolt"]
 nexus = ["dep:ere-nexus"]
 openvm = ["dep:ere-openvm"]

--- a/crates/ere-cli/src/lib.rs
+++ b/crates/ere-cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod serde;

--- a/crates/ere-cli/src/lib.rs
+++ b/crates/ere-cli/src/lib.rs
@@ -1,1 +1,3 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 pub mod serde;

--- a/crates/ere-cli/src/main.rs
+++ b/crates/ere-cli/src/main.rs
@@ -1,26 +1,25 @@
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
-
 use anyhow::{Context, Error};
 use clap::{Parser, Subcommand};
+use ere_cli::serde;
 use std::{fs, path::PathBuf};
 use tracing_subscriber::EnvFilter;
 use zkvm_interface::{Compiler, ProverResourceType, zkVM};
 
-mod serde;
-
 // Compile-time check to ensure exactly one backend feature is enabled
 const _: () = {
-    assert!(
-        (cfg!(feature = "jolt") as u8
-            + cfg!(feature = "nexus") as u8
-            + cfg!(feature = "openvm") as u8
-            + cfg!(feature = "pico") as u8
-            + cfg!(feature = "risc0") as u8
-            + cfg!(feature = "sp1") as u8
-            + cfg!(feature = "zisk") as u8)
-            == 1,
-        "Exactly one zkVM backend feature must be enabled"
-    );
+    if cfg!(feature = "cli") {
+        assert!(
+            (cfg!(feature = "jolt") as u8
+                + cfg!(feature = "nexus") as u8
+                + cfg!(feature = "openvm") as u8
+                + cfg!(feature = "pico") as u8
+                + cfg!(feature = "risc0") as u8
+                + cfg!(feature = "sp1") as u8
+                + cfg!(feature = "zisk") as u8)
+                == 1,
+            "Exactly one zkVM backend feature must be enabled"
+        );
+    }
 };
 
 #[derive(Parser)]

--- a/crates/ere-dockerized/Cargo.toml
+++ b/crates/ere-dockerized/Cargo.toml
@@ -17,6 +17,7 @@ risc0-zkvm.workspace = true
 
 # Local dependencies
 zkvm-interface = { workspace = true, features = ["clap"] }
+ere-cli = { workspace = true }
 
 [dev-dependencies]
 

--- a/crates/ere-dockerized/Cargo.toml
+++ b/crates/ere-dockerized/Cargo.toml
@@ -17,7 +17,7 @@ risc0-zkvm.workspace = true
 
 # Local dependencies
 zkvm-interface = { workspace = true, features = ["clap"] }
-ere-cli = { workspace = true }
+ere-cli.workspace = true
 
 [dev-dependencies]
 

--- a/crates/ere-nexus/src/lib.rs
+++ b/crates/ere-nexus/src/lib.rs
@@ -66,52 +66,32 @@ impl EreNexus {
     }
 }
 impl zkVM for EreNexus {
-    fn execute(&self, inputs: &Input) -> Result<zkvm_interface::ProgramExecutionReport, zkVMError> {
-        let start = Instant::now();
+    fn execute(
+        &self,
+        _inputs: &Input,
+    ) -> Result<zkvm_interface::ProgramExecutionReport, zkVMError> {
+        // TODO: Serialize inputs by `postcard` and make sure there is no double serailization.
+        // Issue for tracking: https://github.com/eth-act/ere/issues/63.
 
-        // let mut public_input = vec![];
-        let mut private_input = vec![];
-        for input in inputs.iter() {
-            private_input.extend(
-                input
-                    .as_bytes()
-                    .map_err(|err| NexusError::Prove(ProveError::Client(err)))
-                    .map_err(zkVMError::from)?,
-            );
-        }
-        // TODO: Doesn't catch execute for guest in nexus. so only left some dummy code(parse input) here.
-        //      Besides, public input is not supported yet, so we just pass an empty tuple
+        // TODO: Execute and get cycle count
 
-        Ok(ProgramExecutionReport {
-            execution_duration: start.elapsed(),
-            ..Default::default()
-        })
+        Ok(ProgramExecutionReport::default())
     }
 
     fn prove(
         &self,
-        inputs: &Input,
+        _inputs: &Input,
     ) -> Result<(Vec<u8>, zkvm_interface::ProgramProvingReport), zkVMError> {
         let prover: Stwo<Local> = Stwo::new_from_file(&self.program.to_string_lossy().to_string())
             .map_err(|e| NexusError::Prove(ProveError::Client(e.into())))
             .map_err(zkVMError::from)?;
 
-        // One convention that may be useful for simplifying the design is that all inputs to the vm are private and all outputs are public.
-        // If an input should be public, then it could just be returned from the function.
-        // let mut public_input = vec![];
-        let mut private_input = vec![];
-        for input in inputs.iter() {
-            private_input.extend(
-                input
-                    .as_bytes()
-                    .map_err(|err| NexusError::Prove(ProveError::Client(err)))
-                    .map_err(zkVMError::from)?,
-            );
-        }
+        // TODO: Serialize inputs by `postcard` and make sure there is no double serailization.
+        // Issue for tracking: https://github.com/eth-act/ere/issues/63.
 
         let now = Instant::now();
         let (_view, proof) = prover
-            .prove_with_input(&private_input, &())
+            .prove_with_input(&(), &())
             .map_err(|e| NexusError::Prove(ProveError::Client(e.into())))
             .map_err(zkVMError::from)?;
         let elapsed = now.elapsed();

--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -133,12 +133,7 @@ impl zkVM for EreOpenVM {
         let sdk = Sdk::new();
 
         let mut stdin = StdIn::default();
-        for input in inputs.iter() {
-            match input {
-                InputItem::Object(serialize) => stdin.write(serialize),
-                InputItem::Bytes(items) => stdin.write_bytes(items),
-            }
-        }
+        serialize_inputs(&mut stdin, inputs);
 
         let start = Instant::now();
         let _outputs = sdk
@@ -162,12 +157,7 @@ impl zkVM for EreOpenVM {
         let sdk = Sdk::new();
 
         let mut stdin = StdIn::default();
-        for input in inputs.iter() {
-            match input {
-                InputItem::Object(serialize) => stdin.write(serialize),
-                InputItem::Bytes(items) => stdin.write_bytes(items),
-            }
-        }
+        serialize_inputs(&mut stdin, inputs);
 
         let now = std::time::Instant::now();
         let proof = sdk
@@ -198,6 +188,17 @@ impl zkVM for EreOpenVM {
 
     fn sdk_version(&self) -> &'static str {
         SDK_VERSION
+    }
+}
+
+fn serialize_inputs(stdin: &mut StdIn, inputs: &Input) {
+    for input in inputs.iter() {
+        match input {
+            InputItem::Object(obj) => stdin.write(obj),
+            InputItem::SerializedObject(bytes) | InputItem::Bytes(bytes) => {
+                stdin.write_bytes(bytes)
+            }
+        }
     }
 }
 

--- a/crates/ere-pico/Cargo.toml
+++ b/crates/ere-pico/Cargo.toml
@@ -10,6 +10,7 @@ bincode.workspace = true
 thiserror.workspace = true
 
 # Pico dependencies
+pico-vm.workspace = true
 pico-sdk.workspace = true
 
 # Local dependencies

--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -162,12 +162,7 @@ impl EreSP1 {
 impl zkVM for EreSP1 {
     fn execute(&self, inputs: &Input) -> Result<zkvm_interface::ProgramExecutionReport, zkVMError> {
         let mut stdin = SP1Stdin::new();
-        for input in inputs.iter() {
-            match input {
-                InputItem::Object(serialize) => stdin.write(serialize),
-                InputItem::Bytes(items) => stdin.write_slice(items),
-            }
-        }
+        serialize_inputs(&mut stdin, inputs);
 
         let client = Self::create_client(&self.resource);
         let start = Instant::now();
@@ -186,12 +181,7 @@ impl zkVM for EreSP1 {
         info!("Generating proof…");
 
         let mut stdin = SP1Stdin::new();
-        for input in inputs.iter() {
-            match input {
-                InputItem::Object(serialize) => stdin.write(serialize),
-                InputItem::Bytes(items) => stdin.write_slice(items),
-            };
-        }
+        serialize_inputs(&mut stdin, inputs);
 
         let client = Self::create_client(&self.resource);
         let start = std::time::Instant::now();
@@ -220,6 +210,17 @@ impl zkVM for EreSP1 {
 
     fn sdk_version(&self) -> &'static str {
         SDK_VERSION
+    }
+}
+
+fn serialize_inputs(stdin: &mut SP1Stdin, inputs: &Input) {
+    for input in inputs.iter() {
+        match input {
+            InputItem::Object(obj) => stdin.write(obj),
+            InputItem::SerializedObject(bytes) | InputItem::Bytes(bytes) => {
+                stdin.write_slice(bytes)
+            }
+        }
     }
 }
 

--- a/crates/ere-zisk/src/lib.rs
+++ b/crates/ere-zisk/src/lib.rs
@@ -15,8 +15,8 @@ use std::{
 };
 use tempfile::{TempDir, tempdir};
 use zkvm_interface::{
-    Compiler, Input, ProgramExecutionReport, ProgramProvingReport, ProverResourceType, zkVM,
-    zkVMError,
+    Compiler, Input, InputItem, ProgramExecutionReport, ProgramProvingReport, ProverResourceType,
+    zkVM, zkVMError,
 };
 
 include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
@@ -56,18 +56,12 @@ impl EreZisk {
     }
 }
 
-impl EreZisk {}
-
 impl zkVM for EreZisk {
-    fn execute(&self, input: &Input) -> Result<ProgramExecutionReport, zkVMError> {
+    fn execute(&self, inputs: &Input) -> Result<ProgramExecutionReport, zkVMError> {
         // Write ELF and serialized input to file.
 
-        let input_bytes = input
-            .iter()
-            .try_fold(Vec::new(), |mut acc, item| {
-                acc.extend(item.as_bytes().map_err(ExecuteError::SerializeInput)?);
-                Ok(acc)
-            })
+        let input_bytes = serialize_inputs(inputs)
+            .map_err(|err| ExecuteError::SerializeInput(err.into()))
             .map_err(ZiskError::Execute)?;
 
         let mut tempdir =
@@ -119,15 +113,11 @@ impl zkVM for EreZisk {
         })
     }
 
-    fn prove(&self, input: &Input) -> Result<(Vec<u8>, ProgramProvingReport), zkVMError> {
+    fn prove(&self, inputs: &Input) -> Result<(Vec<u8>, ProgramProvingReport), zkVMError> {
         // Write ELF and serialized input to file.
 
-        let input_bytes = input
-            .iter()
-            .try_fold(Vec::new(), |mut acc, item| {
-                acc.extend(item.as_bytes().map_err(ProveError::SerializeInput)?);
-                Ok(acc)
-            })
+        let input_bytes = serialize_inputs(inputs)
+            .map_err(|err| ProveError::SerializeInput(err.into()))
             .map_err(ZiskError::Prove)?;
 
         let mut tempdir =
@@ -292,6 +282,18 @@ impl zkVM for EreZisk {
     fn sdk_version(&self) -> &'static str {
         SDK_VERSION
     }
+}
+
+fn serialize_inputs(inputs: &Input) -> Result<Vec<u8>, bincode::Error> {
+    inputs.iter().try_fold(Vec::new(), |mut acc, item| {
+        match item {
+            InputItem::Object(obj) => {
+                bincode::serialize_into(&mut acc, obj)?;
+            }
+            InputItem::SerializedObject(bytes) | InputItem::Bytes(bytes) => acc.extend(bytes),
+        };
+        Ok(acc)
+    })
 }
 
 fn dot_zisk_dir_path() -> PathBuf {

--- a/crates/zkvm-interface/Cargo.toml
+++ b/crates/zkvm-interface/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 auto_impl.workspace = true
-bincode.workspace = true
 erased-serde.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
@@ -17,6 +16,7 @@ thiserror.workspace = true
 clap = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
+bincode.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /ere
 
 ARG ZKVM
 
-RUN cargo build --release --package ere-cli --bin ere-cli --features ${ZKVM} && \
+RUN cargo build --release --package ere-cli --bin ere-cli --features cli,${ZKVM} && \
     cp /ere/target/release/ere-cli /ere/ere-cli && \
     cargo clean && \
     rm -rf $CARGO_HOME/registry/src $CARGO_HOME/registry/cache


### PR DESCRIPTION
This is required for using dockerized `risc0` (`ere-dockerized` calling `ere-cli` with feature `risc0`).

In `risc0` there are multiple way to write the input:
- `write::<T: Serialize>(obj: T)` - It serializes the object with its own serializer, used to serialize `InputItem::Object`
- `write_frame(bytes: Vec<u8>)` - It serializes it by `[bytes.len().as_le_bytes(), bytes].concat()`, use to serialize `InputItem::Bytes`
- `write_slice(bytes: Vec<u8>)` - It doesn't do extra serialization and just append the bytes to its input, not used in ere currently

Currently `ere-dockerized` needs to serialize the `InputItem::Object` to be able to pass it to `ere-cli` by file, this works for most zkVMs that doesn't do extra serialization on the `InputItem::Bytes`, but doesn't work for `risc0`.

For this PR add an extra variant `InputItem::SerializedObject` for `risc0` to identify that it's already serialized in its own serializer, and shuold be appended to its input directly by calling `write_slice`.