### PR TITLE
Add GPU proving support in `ere-openvm`

### DIFF
--- a/.github/workflows/test-zkvm-jolt.yml
+++ b/.github/workflows/test-zkvm-jolt.yml
@@ -16,4 +16,5 @@ jobs:
       zkvm: jolt
       toolchain: 1.86.0
       test_ere_dockerized: false
+      default_features: true
       test_options: ''

--- a/.github/workflows/test-zkvm-nexus.yml
+++ b/.github/workflows/test-zkvm-nexus.yml
@@ -16,4 +16,5 @@ jobs:
       zkvm: nexus
       toolchain: nightly-2025-04-06
       test_ere_dockerized: false
+      default_features: true
       test_options: ''

--- a/.github/workflows/test-zkvm-openvm.yml
+++ b/.github/workflows/test-zkvm-openvm.yml
@@ -16,4 +16,5 @@ jobs:
       zkvm: openvm
       toolchain: 1.86.0
       test_ere_dockerized: true
+      default_features: false
       test_options: ''

--- a/.github/workflows/test-zkvm-pico.yml
+++ b/.github/workflows/test-zkvm-pico.yml
@@ -16,4 +16,5 @@ jobs:
       zkvm: pico
       toolchain: nightly-2025-08-04
       test_ere_dockerized: false
+      default_features: true
       test_options: ''

--- a/.github/workflows/test-zkvm-risc0.yml
+++ b/.github/workflows/test-zkvm-risc0.yml
@@ -16,4 +16,5 @@ jobs:
       zkvm: risc0
       toolchain: 1.86.0
       test_ere_dockerized: true
+      default_features: true
       test_options: ''

--- a/.github/workflows/test-zkvm-sp1.yml
+++ b/.github/workflows/test-zkvm-sp1.yml
@@ -16,4 +16,5 @@ jobs:
       zkvm: sp1
       toolchain: 1.86.0
       test_ere_dockerized: true
+      default_features: true
       test_options: ''

--- a/.github/workflows/test-zkvm.yml
+++ b/.github/workflows/test-zkvm.yml
@@ -17,6 +17,12 @@ on:
         required: false
         type: boolean
         default: true
+      # Currently only needed by those zkvms that need Cuda during building process by default
+      default_features:
+        description: 'Cargo clippy/build with default features or not'
+        required: false
+        type: boolean
+        default: true
       # Remove when we use larger runners, currently only needed to skip some zisk test
       test_options:
         description: 'Cargo test options when testing via Docker'
@@ -45,12 +51,14 @@ jobs:
         run: |
           cargo clippy --all-targets \
             --package ere-${{ inputs.zkvm }} \
+            ${{ inputs.default_features && '' || '--no-default-features' }} \
             -- -D warnings
 
       - name: Run cargo clippy for ere-cli with feature ${{ inputs.zkvm }}
         run: |
           cargo clippy --all-targets \
             --package ere-cli \
+            ${{ inputs.default_features && '' || '--no-default-features' }} \
             --features cli,${{ inputs.zkvm }} \
             -- -D warnings
 
@@ -64,6 +72,7 @@ jobs:
       image_version: ${{ steps.inspect_image.outputs.image_version }}
       base_image_tag: ${{ steps.inspect_image.outputs.base_image_tag }}
       base_zkvm_image_tag: ${{ steps.inspect_image.outputs.base_zkvm_image_tag }}
+      cli_zkvm_image_tag: ${{ steps.inspect_image.outputs.cli_zkvm_image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -86,10 +95,12 @@ jobs:
           IMAGE_VERSION="$ZKVM_CRATE_VERSION-$GIT_REV"
           BASE_IMAGE_TAG="ghcr.io/${{ github.repository }}/ere-base:$IMAGE_VERSION"
           BASE_ZKVM_IMAGE_TAG="ghcr.io/${{ github.repository }}/ere-base-${{ inputs.zkvm }}:$IMAGE_VERSION"
+          CLI_ZKVM_IMAGE_TAG="ghcr.io/${{ github.repository }}/ere-cli-${{ inputs.zkvm }}:$IMAGE_VERSION"
 
           echo "image_version=$IMAGE_VERSION" >> $GITHUB_OUTPUT
           echo "base_image_tag=$BASE_IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "base_zkvm_image_tag=$BASE_ZKVM_IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "cli_zkvm_image_tag=$CLI_ZKVM_IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Build ere-base image
         uses: docker/build-push-action@v6
@@ -107,8 +118,8 @@ jobs:
           push: true
           tags: ${{ steps.inspect_image.outputs.base_zkvm_image_tag }}
           build-args: |
-            CI=1
             BASE_IMAGE_TAG=${{ steps.inspect_image.outputs.base_image_tag }}
+            CI=1
 
   test_via_docker:
     name: Test via Docker
@@ -138,8 +149,11 @@ jobs:
             --volume ${{ github.workspace }}:/ere \
             --workdir /ere \
             ${{ needs.build_image.outputs.base_zkvm_image_tag }} \
-            /bin/sh -c "\$(RUSTFLAGS=-Ctarget-cpu=native cargo test --release --package ere-${{ inputs.zkvm }} --no-run --message-format json \
-              | jq -r 'select(.executable) | select(.package_id | contains(\"ere-${{ inputs.zkvm }}\")) | .executable') \
+            /bin/bash -c "set -o pipefail && \
+              \$(RUSTFLAGS=-Ctarget-cpu=native cargo test --release --package ere-${{ inputs.zkvm }} \
+                  ${{ inputs.default_features && '' || '--no-default-features' }} \
+                  --no-run --message-format json \
+                 | jq -r 'select(.executable) | select(.package_id | contains(\"ere-${{ inputs.zkvm }}\")) | .executable') \
               ${{ inputs.test_options }}"
 
   test_ere_dockerized:
@@ -169,12 +183,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build ere-cli-${{ inputs.zkvm }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/cli/Dockerfile
+          push: true
+          tags: ${{ needs.build_image.outputs.cli_zkvm_image_tag }}
+          build-args: |
+            BASE_ZKVM_IMAGE_TAG=${{ needs.build_image.outputs.base_zkvm_image_tag }}
+            ZKVM=${{ inputs.zkvm }}
+            CI=1
+
       - name: Pull image ere-base and ere-base-${{ inputs.zkvm }}
         run: |
           docker image pull ${{ needs.build_image.outputs.base_image_tag }}
           docker image pull ${{ needs.build_image.outputs.base_zkvm_image_tag }}
+          docker image pull ${{ needs.build_image.outputs.cli_zkvm_image_tag }}
           docker image tag ${{ needs.build_image.outputs.base_image_tag }} ere-base:${{ needs.build_image.outputs.image_version }}
           docker image tag ${{ needs.build_image.outputs.base_zkvm_image_tag }} ere-base-${{ inputs.zkvm }}:${{ needs.build_image.outputs.image_version }}
+          docker image tag ${{ needs.build_image.outputs.cli_zkvm_image_tag }} ere-cli-${{ inputs.zkvm }}:${{ needs.build_image.outputs.image_version }}
 
       - name: Run cargo test for ere-${{ inputs.zkvm }} via ere-dockerized
         run: cargo test --release --package ere-dockerized -- ${{ inputs.zkvm }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "build-utils"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "cargo_metadata 0.19.2",
  "thiserror 2.0.12",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "ere-cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "ere-dockerized"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bincode 1.3.3",
  "build-utils",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "ere-jolt"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "ark-serialize 0.5.0",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "ere-nexus"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bincode 1.3.3",
  "build-utils",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "ere-openvm"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "build-utils",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "ere-pico"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "ere-risc0"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "ere-sp1"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bincode 1.3.3",
  "build-utils",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zisk"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bincode 1.3.3",
  "blake3",
@@ -9523,7 +9523,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bincode 1.3.3",
  "rand 0.9.2",
@@ -10999,7 +10999,7 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "auto_impl",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4695,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -4708,8 +4708,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4740,8 +4740,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-complex-macros"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4750,8 +4750,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -4766,8 +4766,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4778,8 +4778,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4792,8 +4792,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4818,8 +4818,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -4827,8 +4827,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4842,8 +4842,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -4854,8 +4854,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4892,8 +4892,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -4903,8 +4903,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4921,8 +4921,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4931,8 +4931,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4946,8 +4946,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-cuda-backend"
-version = "1.2.0-rc.7"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+version = "1.2.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -4978,8 +4978,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-cuda-builder"
-version = "1.2.0-rc.7"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+version = "1.2.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
 dependencies = [
  "cc",
  "glob",
@@ -4987,8 +4987,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-cuda-common"
-version = "1.2.0-rc.7"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+version = "1.2.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
 dependencies = [
  "bytesize",
  "lazy_static",
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5010,8 +5010,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5042,8 +5042,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -5061,8 +5061,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -5071,8 +5071,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -5085,8 +5085,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -5102,8 +5102,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5111,8 +5111,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5139,16 +5139,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5161,16 +5161,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "syn 2.0.101",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cuda-runtime-sys",
  "itertools 0.14.0",
@@ -5190,8 +5190,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5221,8 +5221,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5243,8 +5243,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5252,8 +5252,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -5276,8 +5276,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -5286,8 +5286,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5317,8 +5317,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal",
@@ -5338,8 +5338,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -5351,8 +5351,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -5361,8 +5361,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -5379,8 +5379,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -5396,8 +5396,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5423,8 +5423,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-custom-insn",
  "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
@@ -5433,8 +5433,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5449,8 +5449,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "bitcode",
  "bon",
@@ -5504,8 +5504,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5515,8 +5515,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5541,16 +5541,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5563,8 +5563,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-version = "1.2.0-rc.7"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+version = "1.2.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -5589,8 +5589,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
-version = "1.2.0-rc.7"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+version = "1.2.0"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0#64c72dba9db8dedad1c936a04fa344b4b9ecb1cd"
 dependencies = [
  "dashmap",
  "derivative",
@@ -5626,8 +5626,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.4.0-rc.9"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
+version = "1.4.0"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0#39ee587f0f73646e3753cb2aa5f34885d4efffe0"
 dependencies = [
  "elf",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,6 +894,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1160,12 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bytesize"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "camino"
@@ -1614,6 +1640,24 @@ checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
  "nix 0.30.1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-runtime-sys"
+version = "0.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d070b301187fee3c611e75a425cf12247b7c75c09729dbdef95cb9cb64e8c39"
+dependencies = [
+ "cuda-config",
 ]
 
 [[package]]
@@ -2247,7 +2291,7 @@ name = "ere-cli"
 version = "0.0.11"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "clap",
  "ere-jolt",
  "ere-nexus",
@@ -2265,7 +2309,7 @@ dependencies = [
 name = "ere-dockerized"
 version = "0.0.11"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "build-utils",
  "bytemuck",
  "ere-cli",
@@ -2301,7 +2345,7 @@ dependencies = [
 name = "ere-nexus"
 version = "0.0.11"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "build-utils",
  "nexus-sdk",
  "serde",
@@ -2338,7 +2382,7 @@ name = "ere-pico"
 version = "0.0.11"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "build-utils",
  "cargo_metadata 0.19.2",
  "pico-sdk",
@@ -2372,7 +2416,7 @@ dependencies = [
 name = "ere-sp1"
 version = "0.0.11"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "build-utils",
  "serde",
  "sp1-sdk",
@@ -2388,7 +2432,7 @@ dependencies = [
 name = "ere-zisk"
 version = "0.0.11"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "blake3",
  "build-utils",
  "dashmap",
@@ -3609,7 +3653,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "ark-serialize-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-std 0.5.0",
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "clap",
  "common",
@@ -4651,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -4664,8 +4708,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4679,6 +4723,9 @@ dependencies = [
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-mod-circuit-builder",
  "openvm-rv32-adapters",
@@ -4693,8 +4740,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-complex-macros"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4703,8 +4750,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -4719,8 +4766,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4731,8 +4778,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4745,8 +4792,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4756,6 +4803,9 @@ dependencies = [
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-rv32-adapters",
  "openvm-rv32im-circuit",
@@ -4768,8 +4818,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -4777,8 +4827,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4792,8 +4842,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -4804,8 +4854,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4822,6 +4872,9 @@ dependencies = [
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-poseidon2-air",
  "openvm-stark-backend",
@@ -4839,8 +4892,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -4850,15 +4903,17 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
  "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-stark-backend",
  "rand 0.8.5",
  "tracing",
@@ -4866,8 +4921,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4876,8 +4931,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4890,18 +4945,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-cuda-backend"
+version = "1.2.0-rc.7"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+dependencies = [
+ "bincode 2.0.1",
+ "bincode_derive",
+ "derivative",
+ "derive-new 0.7.0",
+ "itertools 0.14.0",
+ "lazy_static",
+ "metrics",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
+ "openvm-stark-backend",
+ "openvm-stark-sdk",
+ "p3-baby-bear 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-commit 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-dft 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-fri 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-matrix 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-merkle-tree 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-symmetric 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "p3-util 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "openvm-cuda-builder"
-version = "1.2.0-rc.6"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.6#ba4e49e1c48abb247720c43eba392fbb5c9eea51"
+version = "1.2.0-rc.7"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
 dependencies = [
  "cc",
  "glob",
 ]
 
 [[package]]
+name = "openvm-cuda-common"
+version = "1.2.0-rc.7"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
+dependencies = [
+ "bytesize",
+ "lazy_static",
+ "metrics",
+ "openvm-cuda-builder",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4910,8 +5010,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4926,11 +5026,14 @@ dependencies = [
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
+ "openvm-cuda-backend",
+ "openvm-cuda-common",
  "openvm-ecc-transpiler",
  "openvm-instructions",
  "openvm-mod-circuit-builder",
  "openvm-rv32-adapters",
  "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.8.5",
  "serde",
  "serde_with",
@@ -4939,8 +5042,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4958,8 +5061,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4968,8 +5071,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4982,8 +5085,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4999,8 +5102,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5008,8 +5111,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5019,6 +5122,9 @@ dependencies = [
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-keccak256-transpiler",
  "openvm-rv32im-circuit",
@@ -5033,16 +5139,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5055,23 +5161,26 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "syn 2.0.101",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
+ "cuda-runtime-sys",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-circuit",
  "openvm-circuit-primitives",
+ "openvm-cuda-backend",
  "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-stark-backend",
  "openvm-stark-sdk",
@@ -5081,8 +5190,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5093,6 +5202,9 @@ dependencies = [
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-native-compiler",
  "openvm-poseidon2-air",
@@ -5109,8 +5221,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5131,8 +5243,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -5140,8 +5252,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -5164,8 +5276,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -5174,8 +5286,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5188,6 +5300,7 @@ dependencies = [
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
+ "openvm-cuda-backend",
  "openvm-ecc-circuit",
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -5196,6 +5309,7 @@ dependencies = [
  "openvm-pairing-transpiler",
  "openvm-rv32im-circuit",
  "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.8.5",
  "serde",
  "strum 0.26.3",
@@ -5203,8 +5317,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal",
@@ -5224,8 +5338,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -5237,8 +5351,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -5247,8 +5361,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -5265,8 +5379,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -5282,8 +5396,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5295,9 +5409,13 @@ dependencies = [
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
  "openvm-circuit-primitives-derive",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-rv32im-transpiler",
  "openvm-stark-backend",
+ "openvm-stark-sdk",
  "rand 0.8.5",
  "serde",
  "strum 0.26.3",
@@ -5305,8 +5423,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-custom-insn",
  "p3-field 0.1.0 (git+https://github.com/Plonky3/Plonky3.git?rev=539bbc84085efb609f4f62cb03cf49588388abdb)",
@@ -5315,8 +5433,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5331,8 +5449,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "bitcode",
  "bon",
@@ -5354,6 +5472,7 @@ dependencies = [
  "openvm-build",
  "openvm-circuit",
  "openvm-continuations",
+ "openvm-cuda-backend",
  "openvm-ecc-circuit",
  "openvm-ecc-transpiler",
  "openvm-keccak256-circuit",
@@ -5385,8 +5504,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5396,8 +5515,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5405,6 +5524,9 @@ dependencies = [
  "openvm-circuit",
  "openvm-circuit-derive",
  "openvm-circuit-primitives",
+ "openvm-cuda-backend",
+ "openvm-cuda-builder",
+ "openvm-cuda-common",
  "openvm-instructions",
  "openvm-rv32im-circuit",
  "openvm-sha256-air",
@@ -5419,16 +5541,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-platform",
 ]
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5441,8 +5563,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-backend"
-version = "1.2.0-rc.6"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.6#ba4e49e1c48abb247720c43eba392fbb5c9eea51"
+version = "1.2.0-rc.7"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
 dependencies = [
  "bitcode",
  "cfg-if",
@@ -5467,8 +5589,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-stark-sdk"
-version = "1.2.0-rc.6"
-source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.6#ba4e49e1c48abb247720c43eba392fbb5c9eea51"
+version = "1.2.0-rc.7"
+source = "git+https://github.com/openvm-org/stark-backend.git?tag=v1.2.0-rc.7#39fa5d0c2ce5beae899be42786153f9e489fc068"
 dependencies = [
  "dashmap",
  "derivative",
@@ -5504,8 +5626,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.4.0-rc.8"
-source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.8#c33320cce6f6a5c030c04306bef5d2d7bfc05bce"
+version = "1.4.0-rc.9"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.9#94d04672ef7b5508d335d6baa777acf508d4958e"
 dependencies = [
  "elf",
  "eyre",
@@ -6651,7 +6773,7 @@ name = "pico-patch-libs"
 version = "1.1.6"
 source = "git+https://github.com/brevis-network/pico.git?tag=v1.1.7#79b10e613c3a0dd2a92d2a65a149d853f4aface2"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "serde",
 ]
 
@@ -6661,7 +6783,7 @@ version = "1.1.6"
 source = "git+https://github.com/brevis-network/pico.git?tag=v1.1.7#79b10e613c3a0dd2a92d2a65a149d853f4aface2"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "cfg-if",
  "env_logger",
  "getrandom 0.2.16",
@@ -6689,7 +6811,7 @@ dependencies = [
  "anyhow",
  "arrayref",
  "backtrace",
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "cfg-if",
  "clap",
@@ -7859,7 +7981,7 @@ checksum = "0fdf8d11f9e61cfd3e577fb6e6e11cc34ca247831c2555ee0a6a53deba9702d2"
 dependencies = [
  "addr2line",
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "borsh",
  "bytemuck",
  "bytes",
@@ -8629,7 +8751,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a585a154b0b43d75481c5e58057c3dd72d88c8a36b30205a2365718e493cd2d"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "bytemuck",
  "clap",
  "elf",
@@ -8668,7 +8790,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20e23baf403939adcbe73070bf03f41da26e0d4a18382408a945606cb168fb0d"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "cbindgen",
  "cc",
  "cfg-if",
@@ -8725,7 +8847,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2efa1d0adcc7744ca6427898ba8ce4e8a5d94540e674b5c2e136821f086376f"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "ctrlc",
  "prost 0.13.5",
  "serde",
@@ -8774,7 +8896,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5504d5a422be065fa8f1fc49ff5208017d6e3fe7e392a7761e73178581f5f35d"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "blake3",
  "cfg-if",
  "hex",
@@ -8795,7 +8917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afaa1d5a3ccb8b366ec109c396681fdc07d8c637aa6003889f171aaac86d18ed"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "clap",
  "dirs 5.0.1",
  "downloader",
@@ -8950,7 +9072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b10e8e6519c601ee244ff29d2746787d524034b4dbe42a1d66f901386396febd"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "bindgen",
  "cc",
  "cfg-if",
@@ -8980,7 +9102,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
- "bincode",
+ "bincode 1.3.3",
  "cfg-if",
  "dirs 5.0.1",
  "eventsource-stream",
@@ -9403,7 +9525,7 @@ dependencies = [
 name = "test-utils"
 version = "0.0.11"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "rand 0.9.2",
  "serde",
  "sha2",
@@ -10047,6 +10169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10118,6 +10246,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -10868,7 +11002,7 @@ name = "zkvm-interface"
 version = "0.0.11"
 dependencies = [
  "auto_impl",
- "bincode",
+ "bincode 1.3.3",
  "clap",
  "erased-serde",
  "indexmap 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ jolt-sdk = { git = "https://github.com/a16z/jolt.git", rev = "55b9830a3944dde55d
 nexus-sdk = { git = "https://github.com/nexus-xyz/nexus-zkvm.git", tag = "v0.3.4" }
 
 # OpenVM dependencies
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.8" }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.8" }
-openvm-continuations = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.8" }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.8" }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.6" }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.8" }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
+openvm-continuations = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.7" }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
 
 # Pico dependencies
 pico-vm = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ jolt-sdk = { git = "https://github.com/a16z/jolt.git", rev = "55b9830a3944dde55d
 nexus-sdk = { git = "https://github.com/nexus-xyz/nexus-zkvm.git", tag = "v0.3.4" }
 
 # OpenVM dependencies
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
-openvm-continuations = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
-openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0-rc.7" }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.9" }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
+openvm-continuations = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
+openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
 
 # Pico dependencies
 pico-vm = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,13 +85,13 @@ build-utils = { path = "crates/build-utils" }
 test-utils = { path = "crates/test-utils" }
 ere-cli = { path = "crates/ere-cli", default-features = false }
 ere-dockerized = { path = "crates/ere-dockerized" }
-ere-jolt = { path = "crates/ere-jolt" }
-ere-nexus = { path = "crates/ere-nexus" }
-ere-openvm = { path = "crates/ere-openvm" }
-ere-pico = { path = "crates/ere-pico" }
-ere-risc0 = { path = "crates/ere-risc0" }
-ere-sp1 = { path = "crates/ere-sp1" }
-ere-zisk = { path = "crates/ere-zisk" }
+ere-jolt = { path = "crates/ere-jolt", default-features = false }
+ere-nexus = { path = "crates/ere-nexus", default-features = false }
+ere-openvm = { path = "crates/ere-openvm", default-features = false }
+ere-pico = { path = "crates/ere-pico", default-features = false }
+ere-risc0 = { path = "crates/ere-risc0", default-features = false }
+ere-sp1 = { path = "crates/ere-sp1", default-features = false }
+ere-zisk = { path = "crates/ere-zisk", default-features = false }
 
 [patch.crates-io]
 # These patches are only needed by Jolt

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ bash scripts/sdk_installers/install_sp1_sdk.sh
 ```toml
 # Cargo.toml
 [dependencies]
-zkvm-interface = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.11" }
-ere-sp1        = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.11" }
+zkvm-interface = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.12" }
+ere-sp1        = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.12" }
 ```
 
 #### 3. Compile & Prove Example
@@ -113,8 +113,8 @@ Use Docker for zkVM operations without installing SDKs locally. Only requires Do
 ```toml
 # Cargo.toml
 [dependencies]
-zkvm-interface = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.11" }
-ere-dockerized = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.11" }
+zkvm-interface = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.12" }
+ere-dockerized = { git = "https://github.com/eth-act/ere.git", tag = "v0.0.12" }
 ```
 
 #### 2. Compile & Prove Example

--- a/crates/ere-cli/Cargo.toml
+++ b/crates/ere-cli/Cargo.toml
@@ -28,8 +28,10 @@ zkvm-interface = { workspace = true, features = ["clap"] }
 workspace = true
 
 [features]
-default = []
+default = ["cuda"]
 cli = ["dep:clap", "dep:tracing-subscriber"]
+
+# zkVM
 jolt = ["dep:ere-jolt"]
 nexus = ["dep:ere-nexus"]
 openvm = ["dep:ere-openvm"]
@@ -37,3 +39,6 @@ pico = ["dep:ere-pico"]
 risc0 = ["dep:ere-risc0"]
 sp1 = ["dep:ere-sp1"]
 zisk = ["dep:ere-zisk"]
+
+# Cuda
+cuda = ["ere-openvm?/cuda"]

--- a/crates/ere-dockerized/src/cuda.rs
+++ b/crates/ere-dockerized/src/cuda.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+/// Returns Cuda GPU compute capability, for example
+/// - RTX 50 series - returns `12.0`
+/// - RTX 40 series - returns `8.9`
+///
+/// If there are multiple GPUs available, the first result will be returned.
+pub fn cuda_compute_cap() -> Option<String> {
+    let output = Command::new("nvidia-smi")
+        .args(["--query-gpu=compute_cap", "--format=csv,noheader"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()?
+            .trim()
+            .to_string(),
+    )
+}

--- a/crates/ere-dockerized/src/docker.rs
+++ b/crates/ere-dockerized/src/docker.rs
@@ -63,7 +63,7 @@ impl DockerBuildCmd {
         self.option("tag", tag)
     }
 
-    pub fn bulid_arg(self, key: impl AsRef<str>, value: impl AsRef<str>) -> Self {
+    pub fn build_arg(self, key: impl AsRef<str>, value: impl AsRef<str>) -> Self {
         self.option(
             "build-arg",
             format!("{}={}", to_string(key), to_string(value)),

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -59,6 +59,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use crate::{
+    cuda::cuda_compute_cap,
     docker::{DockerBuildCmd, DockerRunCmd, docker_image_exists},
     error::{CommonError, CompileError, DockerizedError, ExecuteError, ProveError, VerifyError},
 };
@@ -81,6 +82,7 @@ use zkvm_interface::{
 include!(concat!(env!("OUT_DIR"), "/crate_version.rs"));
 include!(concat!(env!("OUT_DIR"), "/zkvm_sdk_version_impl.rs"));
 
+pub mod cuda;
 pub mod docker;
 pub mod error;
 pub mod input;
@@ -166,6 +168,8 @@ impl ErezkVM {
             if matches!(self, ErezkVM::OpenVM) {
                 if let Ok(cuda_arch) = env::var("CUDA_ARCH") {
                     cmd = cmd.build_arg("CUDA_ARCH", cuda_arch)
+                } else if let Some(cuda_compute_cap) = cuda_compute_cap() {
+                    cmd = cmd.build_arg("CUDA_ARCH", cuda_compute_cap.replace(".", ""))
                 }
             };
 

--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -161,11 +161,11 @@ impl ErezkVM {
                 )
                 .tag(self.base_zkvm_tag(CRATE_VERSION))
                 .tag(self.base_zkvm_tag("latest"))
-                .bulid_arg("BASE_IMAGE_TAG", self.base_tag(CRATE_VERSION));
+                .build_arg("BASE_IMAGE_TAG", self.base_tag(CRATE_VERSION));
 
             if matches!(self, ErezkVM::OpenVM) {
                 if let Ok(cuda_arch) = env::var("CUDA_ARCH") {
-                    cmd = cmd.bulid_arg("CUDA_ARCH", cuda_arch)
+                    cmd = cmd.build_arg("CUDA_ARCH", cuda_arch)
                 }
             };
 
@@ -178,8 +178,8 @@ impl ErezkVM {
                 .file(workspace_dir.join("docker").join("cli").join("Dockerfile"))
                 .tag(self.cli_zkvm_tag(CRATE_VERSION))
                 .tag(self.cli_zkvm_tag("latest"))
-                .bulid_arg("BASE_ZKVM_IMAGE_TAG", self.base_zkvm_tag(CRATE_VERSION))
-                .bulid_arg("ZKVM", self.as_str())
+                .build_arg("BASE_ZKVM_IMAGE_TAG", self.base_zkvm_tag(CRATE_VERSION))
+                .build_arg("ZKVM", self.as_str())
                 .exec(&workspace_dir)
                 .map_err(CommonError::DockerBuildCmd)?;
         }

--- a/crates/ere-jolt/src/lib.rs
+++ b/crates/ere-jolt/src/lib.rs
@@ -191,10 +191,10 @@ mod tests {
     use std::sync::OnceLock;
     use test_utils::host::{BasicProgramIo, testing_guest_directory};
 
-    static BASIC_PRORGAM: OnceLock<Vec<u8>> = OnceLock::new();
+    static BASIC_PROGRAM: OnceLock<Vec<u8>> = OnceLock::new();
 
     fn basic_program() -> Vec<u8> {
-        BASIC_PRORGAM
+        BASIC_PROGRAM
             .get_or_init(|| {
                 JOLT_TARGET
                     .compile(&testing_guest_directory("jolt", "basic"))

--- a/crates/ere-nexus/src/lib.rs
+++ b/crates/ere-nexus/src/lib.rs
@@ -160,10 +160,10 @@ mod tests {
     use std::{fs, sync::OnceLock};
     use test_utils::host::testing_guest_directory;
 
-    static BASIC_PRORGAM: OnceLock<PathBuf> = OnceLock::new();
+    static BASIC_PROGRAM: OnceLock<PathBuf> = OnceLock::new();
 
     fn basic_program() -> PathBuf {
-        BASIC_PRORGAM
+        BASIC_PROGRAM
             .get_or_init(|| {
                 NEXUS_TARGET
                     .compile(&testing_guest_directory("nexus", "basic"))

--- a/crates/ere-openvm/Cargo.toml
+++ b/crates/ere-openvm/Cargo.toml
@@ -17,7 +17,7 @@ toml.workspace = true
 openvm-build.workspace = true
 openvm-circuit.workspace = true
 openvm-continuations.workspace = true
-openvm-sdk = { workspace = true, features = ["cuda"] }
+openvm-sdk.workspace = true
 openvm-stark-sdk.workspace = true
 openvm-transpiler.workspace = true
 
@@ -29,6 +29,10 @@ test-utils = { workspace = true, features = ["host"] }
 
 [build-dependencies]
 build-utils.workspace = true
+
+[features]
+default = ["cuda"]
+cuda = ["openvm-sdk/cuda"]
 
 [lints]
 workspace = true

--- a/crates/ere-openvm/Cargo.toml
+++ b/crates/ere-openvm/Cargo.toml
@@ -17,7 +17,7 @@ toml.workspace = true
 openvm-build.workspace = true
 openvm-circuit.workspace = true
 openvm-continuations.workspace = true
-openvm-sdk.workspace = true
+openvm-sdk = { workspace = true, features = ["cuda"] }
 openvm-stark-sdk.workspace = true
 openvm-transpiler.workspace = true
 

--- a/crates/ere-openvm/src/compile_stock_rust.rs
+++ b/crates/ere-openvm/src/compile_stock_rust.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 static CARGO_ENCODED_RUSTFLAGS_SEPARATOR: &str = "\x1f";
 const TARGET_TRIPLE: &str = "riscv32ima-unknown-none-elf";
-// Rust flags according to https://github.com/openvm-org/openvm/blob/v1.4.0-rc.8/crates/toolchain/build/src/lib.rs#L291
+// Rust flags according to https://github.com/openvm-org/openvm/blob/v1.4.0/crates/toolchain/build/src/lib.rs#L291
 const RUSTFLAGS: &[&str] = &[
     // Replace atomic ops with nonatomic versions since the guest is single threaded.
     "-C",

--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -122,6 +122,19 @@ pub struct EreOpenVM {
 
 impl EreOpenVM {
     pub fn new(program: OpenVMProgram, resource: ProverResourceType) -> Result<Self, zkVMError> {
+        match resource {
+            #[cfg(not(feature = "cuda"))]
+            ProverResourceType::Gpu => {
+                panic!("Feature `cuda` is disabled. Enable `cuda` to use GPU resource type")
+            }
+            ProverResourceType::Network(_) => {
+                panic!(
+                    "Network proving not yet implemented for OpenVM. Use CPU or GPU resource type."
+                );
+            }
+            _ => {}
+        }
+
         let sdk = CpuSdk::new(program.app_config.clone()).map_err(CommonError::SdkInit)?;
 
         let elf = Elf::decode(&program.elf, MEM_SIZE as u32)

--- a/crates/ere-pico/src/lib.rs
+++ b/crates/ere-pico/src/lib.rs
@@ -180,10 +180,10 @@ mod tests {
     use std::{panic, sync::OnceLock};
     use test_utils::host::{BasicProgramIo, run_zkvm_execute, testing_guest_directory};
 
-    static BASIC_PRORGAM: OnceLock<Vec<u8>> = OnceLock::new();
+    static BASIC_PROGRAM: OnceLock<Vec<u8>> = OnceLock::new();
 
     fn basic_program() -> Vec<u8> {
-        BASIC_PRORGAM
+        BASIC_PROGRAM
             .get_or_init(|| {
                 PICO_TARGET
                     .compile(&testing_guest_directory("pico", "basic"))

--- a/crates/ere-risc0/src/lib.rs
+++ b/crates/ere-risc0/src/lib.rs
@@ -273,10 +273,10 @@ mod tests {
         BasicProgramIo, run_zkvm_execute, run_zkvm_prove, testing_guest_directory,
     };
 
-    static BASIC_PRORGAM: OnceLock<Risc0Program> = OnceLock::new();
+    static BASIC_PROGRAM: OnceLock<Risc0Program> = OnceLock::new();
 
     fn basic_program() -> Risc0Program {
-        BASIC_PRORGAM
+        BASIC_PROGRAM
             .get_or_init(|| {
                 RV32_IM_RISC0_ZKVM_ELF
                     .compile(&testing_guest_directory("risc0", "basic"))

--- a/crates/ere-sp1/src/lib.rs
+++ b/crates/ere-sp1/src/lib.rs
@@ -256,10 +256,10 @@ mod tests {
         BasicProgramIo, run_zkvm_execute, run_zkvm_prove, testing_guest_directory,
     };
 
-    static BASIC_PRORGAM: OnceLock<Vec<u8>> = OnceLock::new();
+    static BASIC_PROGRAM: OnceLock<Vec<u8>> = OnceLock::new();
 
     fn basic_program() -> Vec<u8> {
-        BASIC_PRORGAM
+        BASIC_PROGRAM
             .get_or_init(|| {
                 RV32_IM_SUCCINCT_ZKVM_ELF
                     .compile(&testing_guest_directory("sp1", "basic"))

--- a/crates/ere-zisk/src/lib.rs
+++ b/crates/ere-zisk/src/lib.rs
@@ -604,10 +604,10 @@ mod tests {
         BasicProgramIo, run_zkvm_execute, run_zkvm_prove, testing_guest_directory,
     };
 
-    static BASIC_PRORGAM: OnceLock<Vec<u8>> = OnceLock::new();
+    static BASIC_PROGRAM: OnceLock<Vec<u8>> = OnceLock::new();
 
     fn basic_program() -> Vec<u8> {
-        BASIC_PRORGAM
+        BASIC_PROGRAM
             .get_or_init(|| {
                 RV64_IMA_ZISK_ZKVM_ELF
                     .compile(&testing_guest_directory("zisk", "basic"))

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -9,7 +9,10 @@ WORKDIR /ere
 ARG ZKVM
 ARG RUSTFLAGS="-Ctarget-cpu=native"
 
-RUN RUSTFLAGS=${RUSTFLAGS} cargo build --release --package ere-cli --bin ere-cli --features cli,${ZKVM} && \
+# If current environment is in CI or not.
+ARG CI
+
+RUN RUSTFLAGS=${RUSTFLAGS} cargo build --release --package ere-cli --bin ere-cli --features cli,${ZKVM} ${CI:+--no-default-features} && \
     cp /ere/target/release/ere-cli /ere/ere-cli && \
     cargo clean && \
     rm -rf $CARGO_HOME/registry/src $CARGO_HOME/registry/cache

--- a/docker/openvm/Dockerfile
+++ b/docker/openvm/Dockerfile
@@ -5,6 +5,26 @@ FROM ${BASE_IMAGE_TAG}
 # The ere-base image provides Rust, Cargo, and common tools.
 # We operate as root for SDK installation.
 
+# If current environment is in CI or not.
+ARG CI
+
+# Install CUDA Toolkit 12.9
+# If argument `CI` is set, we skip the installation.
+RUN [ -n "$CI" ] || \
+    (wget https://developer.download.nvidia.com/compute/cuda/repos/$(. /etc/os-release && echo "${ID}${VERSION_ID}" | tr -d '.')/$(uname -i)/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    rm cuda-keyring_1.1-1_all.deb && \
+    apt update && \
+    apt install -y cuda-toolkit-12-9 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*)
+
+# Add nvcc to path
+ENV PATH=/usr/local/cuda/bin:$PATH
+
+# Default to build for RTX 50 series
+ARG CUDA_ARCH=120
+ENV CUDA_ARCH=${CUDA_ARCH}
+
 # Copy the OpenVM SDK installer script from the workspace context
 COPY scripts/sdk_installers/install_openvm_sdk.sh /tmp/install_openvm_sdk.sh
 RUN chmod +x /tmp/install_openvm_sdk.sh

--- a/scripts/sdk_installers/install_openvm_sdk.sh
+++ b/scripts/sdk_installers/install_openvm_sdk.sh
@@ -28,7 +28,7 @@ ensure_tool_installed "rustup" "to manage Rust toolchains"
 ensure_tool_installed "git" "to install cargo-openvm from a git repository"
 ensure_tool_installed "cargo" "to build and install Rust packages"
 
-OPENVM_CLI_VERSION_TAG="v1.4.0-rc.9"
+OPENVM_CLI_VERSION_TAG="v1.4.0"
 
 # Install cargo-openvm using the specified toolchain and version tag
 echo "Installing cargo-openvm (version ${OPENVM_CLI_VERSION_TAG}) from GitHub repository (openvm-org/openvm)..."
@@ -47,3 +47,7 @@ fi
 
 # Setup aggregation keys
 cargo openvm setup
+
+# Install the toolchain for guest compilation.
+rustup install nightly-2025-02-14
+rustup component add rust-src --toolchain nightly-2025-02-14

--- a/scripts/sdk_installers/install_openvm_sdk.sh
+++ b/scripts/sdk_installers/install_openvm_sdk.sh
@@ -28,7 +28,7 @@ ensure_tool_installed "rustup" "to manage Rust toolchains"
 ensure_tool_installed "git" "to install cargo-openvm from a git repository"
 ensure_tool_installed "cargo" "to build and install Rust packages"
 
-OPENVM_CLI_VERSION_TAG="v1.4.0-rc.8"
+OPENVM_CLI_VERSION_TAG="v1.4.0-rc.9"
 
 # Install cargo-openvm using the specified toolchain and version tag
 echo "Installing cargo-openvm (version ${OPENVM_CLI_VERSION_TAG}) from GitHub repository (openvm-org/openvm)..."

--- a/tests/openvm/basic/Cargo.toml
+++ b/tests/openvm/basic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
-openvm = { git = "https://github.com/openvm-org/openvm.git", features = ["std"], tag = "v1.4.0-rc.8" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", features = ["std"], tag = "v1.4.0-rc.9" }
 test-utils = { path = "../../../crates/test-utils" }

--- a/tests/openvm/basic/Cargo.toml
+++ b/tests/openvm/basic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 bincode = "1.3.3"
-openvm = { git = "https://github.com/openvm-org/openvm.git", features = ["std"], tag = "v1.4.0-rc.9" }
+openvm = { git = "https://github.com/openvm-org/openvm.git", features = ["std"], tag = "v1.4.0" }
 test-utils = { path = "../../../crates/test-utils" }

--- a/tests/openvm/stock_nightly_no_std/src/openvm_rt.rs
+++ b/tests/openvm/stock_nightly_no_std/src/openvm_rt.rs
@@ -35,7 +35,7 @@ fn __start(_argc: isize, _argv: *const *const u8) -> isize {
     unreachable!()
 }
 
-// According to https://github.com/openvm-org/openvm/blob/v1.4.0-rc.8/crates/toolchain/openvm/src/process.rs
+// According to https://github.com/openvm-org/openvm/blob/v1.4.0/crates/toolchain/openvm/src/process.rs
 #[inline(always)]
 fn terminate() {
     unsafe {
@@ -45,7 +45,7 @@ fn terminate() {
     }
 }
 
-// According to https://github.com/openvm-org/openvm/blob/v1.4.0-rc.8/crates/toolchain/openvm/src/process.rs
+// According to https://github.com/openvm-org/openvm/blob/v1.4.0/crates/toolchain/openvm/src/process.rs
 #[panic_handler]
 fn panic_impl(_panic_info: &core::panic::PanicInfo) -> ! {
     unsafe {


### PR DESCRIPTION
- Update `openvm` to `v1.4.0`.
- Add `cuda` feature and enabled by default in `ere-openvm`, and add support of `ProverResourceType::Gpu`
- Add feature flag `cuda` in `ere-cli` as well
- In CI add an boolean option `default_features` to conditional enable/disable default features, which includes `cuda`, to avoid needing cuda to run clippy/test.

I thin eventually we need to handle the cuda building thing on CI, otherwise I feel the building process will get more and more complicated :(