### PR TITLE
Add getters for `EreDockerizedzkVM`

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --all-targets --package ${{ matrix.crate }} -- -D warnings
 
+      - name: Run cargo test on documentation
+        run: cargo test --doc --package ${{ matrix.crate }}
+
       - name: Run cargo test
         if: ${{ matrix.run_test }} 
         run: cargo test --release --package ${{ matrix.crate }}


### PR DESCRIPTION
- Add getters for `EreDockerizedzkVM`
- Move the `build_docker_image` to `EreDockerizedCompiler::new` to be more consistent
- Fix the doc of `ere-dockerized`
- In CI add `cargo test --doc` for common crates.