### PR TITLE
Add clang to ere-base

### DIFF
--- a/docker/base/Dockerfile.base
+++ b/docker/base/Dockerfile.base
@@ -13,6 +13,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
+    clang \
     cmake \
     pkg-config \
     curl \


### PR DESCRIPTION
This PR adds `clang` to the installed packages in `ere-base`.

This is required since some dependencies in guest program require clang for building. As a concrete example, this is the case for [Ethrex guest program](https://github.com/eth-act/zkevm-benchmark-workload/pull/158).