### PR TITLE
Upgrade `risc0-zkvm` to `3.0.3`, also remove unused dep `risc0-zkvm-platform`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5498,7 +5498,17 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive 0.7.4",
+ "rustversion",
 ]
 
 [[package]]
@@ -5511,6 +5521,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8650,9 +8671,9 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-binfmt"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2af322c052ae9973054f67434bc953eae44dbac68054d304b46848634d2a45d"
+checksum = "1c8f97f81bcdead4101bca06469ecef481a2695cd04e7e877b49dea56a7f6f2a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8672,9 +8693,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "3.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b042a8a6fdd02793c0acb526fbd3f0d92abe664f1158be38d45a92def57385b2"
+checksum = "1bbb512d728e011d03ce0958ca7954624ee13a215bcafd859623b3c63b2a3f60"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -8710,9 +8731,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "966ba960d718123e16c603d6919a0c5d7cd2f872d428639ab5650108520f133a"
+checksum = "5f195f865ac1afdc21a172d7756fdcc21be18e13eb01d78d3d7f2b128fa881ba"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8746,9 +8767,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f6afac63cfd291aaa7f40edf976db5452698e66cd79f16ccbf7c0eb5a5d94e"
+checksum = "dca8f15c8abc0fd8c097aa7459879110334d191c63dd51d4c28881c4a497279e"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8783,9 +8804,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdd0865593941a6800c65a7c3b48be8700f73eb597681f6f594c7465839ce8a"
+checksum = "ae1b0689f4a270a2f247b04397ebb431b8f64fe5170e98ee4f9d71bd04825205"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -8843,9 +8864,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68a622c69d0b97f511ee43db1d7f7f00b4dacead9c8aceae03fc5383f4764c1"
+checksum = "724285dc79604abfb2d40feaefe3e335420a6b293511661f77d6af62f1f5fae9"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -8880,19 +8901,20 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.0.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c9f0ec5f6eb8b7624347b5dcf82729f304adbc364399825f3ab6f8588189c"
+checksum = "840c2228803557a8b7dc035a8f196516b6fd68c9dc6ac092f0c86241b5b1bafb"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
+ "risc0-zkvm-platform",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c246f34b86a165308e37a064afa86e66ee7b8525f02bcf03f2124aaeedba04f"
+checksum = "ffb6bf356f469bb8744f72a07a37134c5812c1d55d6271bba80e87bdb7a58c8e"
 dependencies = [
  "anyhow",
  "blake2",
@@ -8921,9 +8943,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "3.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdf8d11f9e61cfd3e577fb6e6e11cc34ca247831c2555ee0a6a53deba9702d2"
+checksum = "3fcce11648a9ff60b8e7af2f0ce7fbf8d25275ab6d414cc91b9da69ee75bc978"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -8970,15 +8992,17 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.4"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fc0e464f4ac44c3f1fd17b479e09e3ccbd1c40219837d750580b03030dca60"
+checksum = "cfaa10feba15828c788837ddde84b994393936d8f5715228627cfe8625122a40"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "getrandom 0.2.16",
  "getrandom 0.3.3",
  "libm",
+ "num_enum 0.7.4",
+ "paste",
  "stability",
 ]
 
@@ -9030,7 +9054,7 @@ version = "0.1.0"
 source = "git+https://github.com/GregAC/rrs/#b23afc16b4e6a1fb5c4a73eb1e337e9400816507"
 dependencies = [
  "downcast-rs",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
 ]
 
@@ -9041,7 +9065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3372685893a9f67d18e98e792d690017287fd17379a83d798d958e517d380fa9"
 dependencies = [
  "downcast-rs",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
 ]
 
@@ -9304,9 +9328,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "rzup"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c6dfdbd72b2b0a537ad1e6256a3ce493ac87b9e89815465e393ee6595968e2"
+checksum = "5d2aed296f203fa64bcb4b52069356dd86d6ec578593985b919b6995bee1f0ae"
 dependencies = [
  "hex",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,9 @@ pico-vm = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }
 pico-sdk = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }
 
 # Risc0 dependencies
-risc0-build = "3.0.1"
-risc0-zkvm = { version = "3.0.1", default-features = false }
-risc0-binfmt = { version = "3.0.1", default-features = false }
+risc0-build = "3.0.3"
+risc0-zkvm = { version = "3.0.3", default-features = false }
+risc0-binfmt = { version = "3.0.2", default-features = false }
 
 # SP1 dependencies
 sp1-sdk = "5.2.1"

--- a/crates/ere-risc0/src/compile_stock_rust.rs
+++ b/crates/ere-risc0/src/compile_stock_rust.rs
@@ -9,10 +9,10 @@ use tracing::info;
 
 static CARGO_ENCODED_RUSTFLAGS_SEPARATOR: &str = "\x1f";
 // TODO: Make this with `zkos` package building to avoid binary file storing in repo.
-// File taken from https://github.com/risc0/risc0/blob/v3.0.1/risc0/zkos/v1compat/elfs/v1compat.elf
+// File taken from https://github.com/risc0/risc0/blob/v3.0.3/risc0/zkos/v1compat/elfs/v1compat.elf
 const V1COMPAT_ELF: &[u8] = include_bytes!("kernel_elf/v1compat.elf");
 const TARGET_TRIPLE: &str = "riscv32ima-unknown-none-elf";
-// Rust flags according to https://github.com/risc0/risc0/blob/v3.0.1/risc0/build/src/lib.rs#L455
+// Rust flags according to https://github.com/risc0/risc0/blob/v3.0.3/risc0/build/src/lib.rs#L455
 const RUSTFLAGS: &[&str] = &[
     "-C",
     "passes=lower-atomic", // Only for rustc > 1.81

--- a/crates/ere-risc0/src/lib.rs
+++ b/crates/ere-risc0/src/lib.rs
@@ -28,7 +28,7 @@ mod output;
 
 /// Default logarithmic segment size from [`DEFAULT_SEGMENT_LIMIT_PO2`].
 ///
-/// [`DEFAULT_SEGMENT_LIMIT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.1/risc0/circuit/rv32im/src/execute/mod.rs#L39.
+/// [`DEFAULT_SEGMENT_LIMIT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.3/risc0/circuit/rv32im/src/execute/mod.rs#L39.
 const DEFAULT_SEGMENT_PO2: usize = 20;
 
 /// Supported range of logarithmic segment size.
@@ -38,18 +38,18 @@ const DEFAULT_SEGMENT_PO2: usize = 20;
 /// The maximum is by [`DEFAULT_MAX_PO2`], although the real maximum is `24`,
 /// but it requires us to set the `control_ids` manually in the `ProverOpts`.
 ///
-/// [`MIN_LIFT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.1/risc0/circuit/recursion/src/control_id.rs#L19
-/// [`DEFAULT_MAX_PO2`]: https://github.com/risc0/risc0/blob/v3.0.1/risc0/zkvm/src/receipt.rs#L884
+/// [`MIN_LIFT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.3/risc0/circuit/recursion/src/control_id.rs#L19
+/// [`DEFAULT_MAX_PO2`]: https://github.com/risc0/risc0/blob/v3.0.3/risc0/zkvm/src/receipt.rs#L884
 const SEGMENT_PO2_RANGE: RangeInclusive<usize> = 14..=DEFAULT_MAX_PO2;
 
 /// Default logarithmic keccak size from [`KECCAK_DEFAULT_PO2`].
 ///
-/// [`KECCAK_DEFAULT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.1/risc0/circuit/keccak/src/lib.rs#L27.
+/// [`KECCAK_DEFAULT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.3/risc0/circuit/keccak/src/lib.rs#L27.
 const DEFAULT_KECCAK_PO2: usize = 17;
 
 /// Supported range of logarithmic keccak size from [`KECCAK_PO2_RANGE`].
 ///
-/// [`KECCAK_PO2_RANGE`]: https://github.com/risc0/risc0/blob/v3.0.1/risc0/circuit/keccak/src/lib.rs#L29.
+/// [`KECCAK_PO2_RANGE`]: https://github.com/risc0/risc0/blob/v3.0.3/risc0/circuit/keccak/src/lib.rs#L29.
 const KECCAK_PO2_RANGE: RangeInclusive<usize> = 14..=18;
 
 #[allow(non_camel_case_types)]

--- a/docker/risc0/Dockerfile
+++ b/docker/risc0/Dockerfile
@@ -15,7 +15,7 @@ RUN [ -n "$CI" ] || \
     apt install -y cuda-toolkit-12-9 clang && \
     apt-get clean && rm -rf /var/lib/apt/lists/*)
 
-# Install protoc with same version as https://github.com/risc0/risc0/blob/v3.0.1/bento/dockerfiles/agent.dockerfile#L24-L26.
+# Install protoc with same version as https://github.com/risc0/risc0/blob/v3.0.3/bento/dockerfiles/agent.dockerfile#L24-L26.
 # If argument `CI` is set, we skip the installation.
 RUN [ -n "$CI" ] || \
     (curl -o protoc.zip -L https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-x86_64.zip && \
@@ -34,7 +34,7 @@ ENV PATH=/usr/local/cuda/bin:$PATH
 COPY --chmod=+x scripts/sdk_installers/install_risc0_sdk.sh /tmp/install_risc0_sdk.sh
 
 # The install_risc0_sdk.sh script will respect these ENV variables.
-ENV RISC0_VERSION="3.0.1" \
+ENV RISC0_VERSION="3.0.3" \
     RISC0_CPP_VERSION="2024.1.5" \
     RISC0_RUST_VERSION="1.88.0"
 

--- a/scripts/sdk_installers/install_risc0_sdk.sh
+++ b/scripts/sdk_installers/install_risc0_sdk.sh
@@ -63,7 +63,7 @@ fi
 # Now that rzup is confirmed to be in PATH for this script, install the Risc0 toolchain
 echo "Running 'rzup install' to install/update Risc0 toolchain..."
 
-RISC0_VERSION="${RISC0_VERSION:-3.0.1}"
+RISC0_VERSION="${RISC0_VERSION:-3.0.3}"
 RISC0_CPP_VERSION="${RISC0_CPP_VERSION:-2024.1.5}"
 RISC0_RUST_VERSION="${RISC0_RUST_VERSION:-1.88.0}"
 

--- a/tests/risc0/allocs_alignment/Cargo.toml
+++ b/tests/risc0/allocs_alignment/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "3.0.1", default-features = false, features = [
+risc0-zkvm = { version = "3.0.3", default-features = false, features = [
     "std",
     "unstable",
 ] }
-risc0-zkvm-platform = { version = "=2.0.4" }

--- a/tests/risc0/basic/Cargo.toml
+++ b/tests/risc0/basic/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "3.0.1", default-features = false, features = ["std", "unstable"] }
-risc0-zkvm-platform = { version = "=2.0.4" }
+risc0-zkvm = { version = "3.0.3", default-features = false, features = ["std", "unstable"] }
 test-utils = { path = "../../../crates/test-utils" }


### PR DESCRIPTION
Upgrade `risc0-zkvm` to `3.0.3`. Also I found the dep `risc0-zkvm-platform` is unused (the `env::cycle_count` is enabled by default), so we don't need to enable its `sys-getenv` feature in `zkevm-benchmark-workload` as well (but probably need to upgrade `risc0-zkvm-platform` to `2.2.1` in `Cargo.lock` if it's not upgraded automatically)
