### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test-zkvm.yml
+++ b/.github/workflows/test-zkvm.yml
@@ -237,7 +237,6 @@ jobs:
 
   test_ere_dockerized:
     name: Test ere-dockerized with the selected zkVM
-    if: ${{ inputs.test_ere_dockerized }}
     needs: build_image
     runs-on: ubuntu-latest
     steps:
@@ -277,6 +276,7 @@ jobs:
             CI=1
 
       - name: Pull images ere-base, ere-base-${{ inputs.zkvm }}, and ere-cli-${{ inputs.zkvm }}
+        if: ${{ inputs.test_ere_dockerized }}
         run: |
           docker image pull ${{ needs.build_image.outputs.base_image_tag }}
           docker image pull ${{ needs.build_image.outputs.base_zkvm_image_tag }}
@@ -286,4 +286,5 @@ jobs:
           docker image tag ${{ needs.build_image.outputs.cli_zkvm_image_tag }} ere-cli-${{ inputs.zkvm }}:${{ needs.build_image.outputs.image_version }}
 
       - name: Run cargo test for ere-${{ inputs.zkvm }} via ere-dockerized
+        if: ${{ inputs.test_ere_dockerized }}
         run: cargo test --release --package ere-dockerized -- ${{ inputs.zkvm }}

--- a/.github/workflows/test-zkvm.yml
+++ b/.github/workflows/test-zkvm.yml
@@ -100,7 +100,7 @@ jobs:
               fi
             fi
 
-            if [ "${{ steps.changed_files.outputs.base_zkvm_any_changed }}" == "false" ]; then
+            if [ "${{ steps.changed_files.outputs.any_changed }}" == "false" ]; then
               if docker buildx imagetools create --tag "$BASE_ZKVM_IMAGE_TAG" "$BASE_ZKVM_IMAGE_NAME:$PR_BASE_IMAGE_VERSION" 2>/dev/null; then
                 echo "Created new tag $BASE_ZKVM_IMAGE_TAG referring to $BASE_ZKVM_IMAGE_NAME:$PR_BASE_IMAGE_VERSION"
                 BUILD_BASE_ZKVM_IMAGE="false"

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -7,7 +7,7 @@ COPY . /ere
 WORKDIR /ere
 
 ARG ZKVM
-ARG RUSTFLAGS="-Ctarget-cpu=native"
+ARG RUSTFLAGS
 
 # If current environment is in CI or not.
 ARG CI


### PR DESCRIPTION
- Remove the `RUSTFLAGS` default value in `ere-cli-{zkvm}` dockerifle
- Build `ere-cli-{zkvm}` even not doing `ere-dockerized` e2e test
- Use `.any_changed` (includes base image changes) to determine if build `ere-base-{zkvm}` or not (didn't cause issue yet but should be fix).
