### PR TITLE
zisk docker image rebuild

### DIFF
--- a/docker/zisk/Dockerfile
+++ b/docker/zisk/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod +x /tmp/install_zisk_sdk.sh
 # Run the ZisK SDK installation script using ziskup.
 # This script installs the 'zisk' Rust toolchain and `cargo-zisk`
 #
-# If argument `CI` is set, we only install verifying key, this is used by github
+# If argument `CI` is set, we only install verifying key, this is used by GitHub
 # CI runner which only has small disk space (proving key requires ~27 GB).
 RUN if [ -n "$CI" ]; then export SETUP_KEY=verify; fi && \
     /tmp/install_zisk_sdk.sh && \


### PR DESCRIPTION
The ZisK team mentioned:
```
the Zisk toolchain has been updated to Rust 1.89.0
You can update your toolchain by running:
cargo-zisk sdk install-toolchain
To verify that it was installed correctly run:
rustup run zisk rustc --version
it should display version 1.89.0
```

I verified this by doing:
```
$ docker run -it --rm ghcr.io/eth-act/ere/ere-base-zisk:0.0.12-7514710
root@31806979e150:/app# cargo-zisk sdk install-toolchain
Successfully cleaned up ~/.zisk directory.
Successfully created ~/.zisk directory.
Downloading https://github.com/0xPolygonHermez/rust/releases/latest/download/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz
Downloaded https://github.com/0xPolygonHermez/rust/releases/latest/download/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz to File { fd: 9, path: "/root/.zisk/rust-toolchain-x86_64-unknown-linux-gnu.tar.gz", read: false, write: true }
  [00:00:08] [###################################################################################################################################################################################################################################] 330.08 MiB/330.08 MiB (37.38 MiB/s, 0s)info: uninstalling toolchain 'zisk'
info: toolchain 'zisk' uninstalled
Successfully removed existing toolchain.
Successfully linked toolchain to rustup.
root@31806979e150:/app# rustup run zisk rustc --version
rustc 1.89.0-dev
root@31806979e150:/app# 
```

Considering there's no new SDK release for this, I think the main way to have an updated ere image is by rebuilding in the CI by touching (any) `Dockerfile`.