### PR TITLE
Complete `ere-pico`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,9 +3695,11 @@ dependencies = [
  "bincode 1.3.3",
  "build-utils",
  "cargo_metadata 0.19.2",
- "pico-sdk",
+ "p3-field 0.1.0 (git+https://github.com/brevis-network/Plonky3.git?rev=a4d376b)",
  "pico-vm",
  "serde",
+ "sha2",
+ "tempfile",
  "test-utils",
  "thiserror 2.0.12",
  "zkvm-interface",
@@ -9625,41 +9627,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "pico-patch-libs"
-version = "1.1.6"
-source = "git+https://github.com/brevis-network/pico.git?tag=v1.1.7#79b10e613c3a0dd2a92d2a65a149d853f4aface2"
-dependencies = [
- "bincode 1.3.3",
- "serde",
-]
-
-[[package]]
-name = "pico-sdk"
-version = "1.1.6"
-source = "git+https://github.com/brevis-network/pico.git?tag=v1.1.7#79b10e613c3a0dd2a92d2a65a149d853f4aface2"
-dependencies = [
- "anyhow",
- "bincode 1.3.3",
- "cfg-if",
- "env_logger",
- "getrandom 0.2.16",
- "hex",
- "lazy_static",
- "log",
- "p3-baby-bear 0.1.0 (git+https://github.com/brevis-network/Plonky3.git?rev=a4d376b)",
- "p3-challenger 0.1.0 (git+https://github.com/brevis-network/Plonky3.git?rev=a4d376b)",
- "p3-field 0.1.0 (git+https://github.com/brevis-network/Plonky3.git?rev=a4d376b)",
- "p3-koala-bear 0.1.0 (git+https://github.com/brevis-network/Plonky3.git?rev=a4d376b)",
- "p3-mersenne-31 0.1.0 (git+https://github.com/brevis-network/Plonky3.git?rev=a4d376b)",
- "pico-patch-libs",
- "pico-vm",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", ta
 openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0" }
 
 # Pico dependencies
+pico-p3-field = { git = "https://github.com/brevis-network/Plonky3.git", package = "p3-field", rev = "a4d376b" }
 pico-vm = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }
-pico-sdk = { git = "https://github.com/brevis-network/pico.git", tag = "v1.1.7" }
 
 # Risc0 dependencies
 risc0-build = "3.0.3"

--- a/crates/ere-dockerized/build.rs
+++ b/crates/ere-dockerized/build.rs
@@ -31,7 +31,7 @@ fn generate_zkvm_sdk_version_impl() {
         "jolt-sdk",
         "nexus-sdk",
         "openvm-sdk",
-        "pico-sdk",
+        "pico-vm",
         "risc0-zkvm",
         "sp1-sdk",
         "zkm-sdk",

--- a/crates/ere-pico/Cargo.toml
+++ b/crates/ere-pico/Cargo.toml
@@ -9,12 +9,14 @@ license.workspace = true
 anyhow.workspace = true
 bincode.workspace = true
 cargo_metadata.workspace = true
+sha2.workspace = true
 serde.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 
 # Pico dependencies
+pico-p3-field.workspace = true
 pico-vm.workspace = true
-pico-sdk.workspace = true
 
 # Local dependencies
 zkvm-interface.workspace = true

--- a/crates/ere-pico/build.rs
+++ b/crates/ere-pico/build.rs
@@ -1,5 +1,5 @@
 use build_utils::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("pico", "pico-sdk");
+    detect_and_generate_name_and_sdk_version("pico", "pico-vm");
 }

--- a/crates/ere-pico/src/client.rs
+++ b/crates/ere-pico/src/client.rs
@@ -1,6 +1,6 @@
 // Copied and modified from https://github.com/brevis-network/pico/blob/v1.1.7/sdk/sdk/src/client.rs.
 // The `EmbedProver` is removed because we don't need the proof to be verified
-// on chain.
+// on chain. Issue for tracking: https://github.com/eth-act/ere/issues/140.
 
 use anyhow::{Error, Ok, Result};
 use pico_vm::{

--- a/crates/ere-pico/src/client.rs
+++ b/crates/ere-pico/src/client.rs
@@ -1,0 +1,99 @@
+// Copied and modified from https://github.com/brevis-network/pico/blob/v1.1.7/sdk/sdk/src/client.rs.
+// The `EmbedProver` is removed because we don't need the proof to be verified
+// on chain.
+
+use anyhow::{Error, Ok, Result};
+use pico_vm::{
+    compiler::riscv::program::Program,
+    configs::{config::StarkGenericConfig, stark_config::KoalaBearPoseidon2},
+    emulator::stdin::EmulatorStdinBuilder,
+    instances::compiler::shapes::{
+        recursion_shape::RecursionShapeConfig, riscv_shape::RiscvShapeConfig,
+    },
+    machine::proof,
+    proverchain::{
+        CombineProver, CompressProver, ConvertProver, InitialProverSetup, MachineProver,
+        ProverChain, RiscvProver,
+    },
+};
+use zkvm_interface::PublicValues;
+
+pub type SC = KoalaBearPoseidon2;
+pub type MetaProof = proof::MetaProof<SC>;
+
+pub struct ProverClient {
+    riscv: RiscvProver<SC, Program>,
+    convert: ConvertProver<SC, SC>,
+    combine: CombineProver<SC, SC>,
+    compress: CompressProver<SC, SC>,
+}
+
+impl ProverClient {
+    pub fn new(elf: &[u8]) -> Self {
+        let riscv = RiscvProver::new_initial_prover(
+            (SC::new(), elf),
+            Default::default(),
+            Some(RiscvShapeConfig::default()),
+        );
+        let convert = ConvertProver::new_with_prev(
+            &riscv,
+            Default::default(),
+            Some(RecursionShapeConfig::default()),
+        );
+        let combine = CombineProver::new_with_prev(
+            &convert,
+            Default::default(),
+            Some(RecursionShapeConfig::default()),
+        );
+        let compress = CompressProver::new_with_prev(&combine, (), None);
+        Self {
+            riscv,
+            convert,
+            combine,
+            compress,
+        }
+    }
+
+    pub fn new_stdin_builder(&self) -> EmulatorStdinBuilder<Vec<u8>, SC> {
+        EmulatorStdinBuilder::default()
+    }
+
+    /// Execute the program and return the cycles and public values
+    pub fn execute(&self, stdin: EmulatorStdinBuilder<Vec<u8>, SC>) -> (u64, Vec<u8>) {
+        let (stdin, _) = stdin.finalize();
+        self.riscv.emulate(stdin)
+    }
+
+    /// Prove until `CompressProver`.
+    pub fn prove(
+        &self,
+        stdin: EmulatorStdinBuilder<Vec<u8>, SC>,
+    ) -> Result<(PublicValues, MetaProof), Error> {
+        let (stdin, _) = stdin.finalize();
+        let riscv_proof = self.riscv.prove(stdin);
+        if !self.riscv.verify(&riscv_proof.clone(), self.riscv.vk()) {
+            return Err(Error::msg("verify riscv proof failed"));
+        }
+        let proof = self.convert.prove(riscv_proof.clone());
+        if !self.convert.verify(&proof, self.riscv.vk()) {
+            return Err(Error::msg("verify convert proof failed"));
+        }
+        let proof = self.combine.prove(proof);
+        if !self.combine.verify(&proof, self.riscv.vk()) {
+            return Err(Error::msg("verify combine proof failed"));
+        }
+        let proof = self.compress.prove(proof);
+        if !self.compress.verify(&proof, self.riscv.vk()) {
+            return Err(Error::msg("verify compress proof failed"));
+        }
+        Ok((riscv_proof.pv_stream.clone().unwrap_or_default(), proof))
+    }
+
+    /// Verify a compressed proof.
+    pub fn verify(&self, proof: &MetaProof) -> Result<(), Error> {
+        if !self.compress.verify(proof, self.riscv.vk()) {
+            return Err(Error::msg("verify compress proof failed"));
+        }
+        Ok(())
+    }
+}

--- a/crates/ere-pico/src/compile_stock_rust.rs
+++ b/crates/ere-pico/src/compile_stock_rust.rs
@@ -1,4 +1,4 @@
-use crate::error::PicoError;
+use crate::error::CompileError;
 use cargo_metadata::MetadataCommand;
 use std::fs;
 use std::path::Path;
@@ -38,18 +38,18 @@ const CARGO_ARGS: &[&str] = &[
 pub fn compile_pico_program_stock_rust(
     guest_directory: &Path,
     toolchain: &String,
-) -> Result<Vec<u8>, PicoError> {
+) -> Result<Vec<u8>, CompileError> {
     compile_program_stock_rust(guest_directory, toolchain)
 }
 
 fn compile_program_stock_rust(
     guest_directory: &Path,
     toolchain: &String,
-) -> Result<Vec<u8>, PicoError> {
+) -> Result<Vec<u8>, CompileError> {
     let metadata = MetadataCommand::new().current_dir(guest_directory).exec()?;
     let package = metadata
         .root_package()
-        .ok_or_else(|| PicoError::MissingPackageName {
+        .ok_or_else(|| CompileError::MissingPackageName {
             path: guest_directory.to_path_buf(),
         })?;
 
@@ -76,7 +76,7 @@ fn compile_program_stock_rust(
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
         .status()
-        .map_err(|source| PicoError::BuildFailure {
+        .map_err(|source| CompileError::BuildFailure {
             source: source.into(),
             crate_path: guest_directory.to_path_buf(),
         });
@@ -87,7 +87,7 @@ fn compile_program_stock_rust(
 
     let elf_path = target_direcotry.join(&package.name);
 
-    fs::read(&elf_path).map_err(|e| PicoError::ReadFile {
+    fs::read(&elf_path).map_err(|e| CompileError::ReadFile {
         path: elf_path,
         source: e,
     })

--- a/crates/ere-pico/src/error.rs
+++ b/crates/ere-pico/src/error.rs
@@ -10,22 +10,35 @@ impl From<PicoError> for zkVMError {
 
 #[derive(Debug, Error)]
 pub enum PicoError {
+    #[error(transparent)]
+    Compile(#[from] CompileError),
+
+    #[error(transparent)]
+    Execute(#[from] ExecuteError),
+
+    #[error(transparent)]
+    Prove(#[from] ProveError),
+
+    #[error(transparent)]
+    Verify(#[from] VerifyError),
+}
+
+#[derive(Debug, Error)]
+pub enum CompileError {
+    #[error("Failed to create temporary directory: {0}")]
+    Tempdir(io::Error),
     /// Guest program directory does not exist.
     #[error("guest program directory not found: {0}")]
     PathNotFound(PathBuf),
-
     /// Failed to spawn or run `cargo pico build`.
     #[error("failed to run `cargo pico build`: {0}")]
-    Spawn(#[from] io::Error),
-
+    CargoPicoBuild(#[from] io::Error),
     /// `cargo pico build` exited with a non-zero status.
     #[error("`cargo pico build` failed with status {status:?}")]
-    CargoFailed { status: ExitStatus },
-
+    CargoPicoBuildFailed { status: ExitStatus },
     /// Expected ELF file was not produced.
     #[error("ELF file not found at {0}")]
     ElfNotFound(PathBuf),
-
     /// Reading the ELF file failed.
     #[error("failed to read ELF file at {path}: {source}")]
     ReadElf {
@@ -49,4 +62,34 @@ pub enum PicoError {
     },
     #[error("`cargo metadata` failed: {0}")]
     MetadataCommand(#[from] cargo_metadata::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum ExecuteError {
+    #[error("Pico execution failed: {0}")]
+    Client(anyhow::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum ProveError {
+    #[error("Pico proving failed: {0}")]
+    Client(anyhow::Error),
+    #[error("Serialising proof with `bincode` failed: {0}")]
+    Bincode(#[from] bincode::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    #[error("Pico verifying failed: {0}")]
+    Client(anyhow::Error),
+    #[error("Deserialising proof with `bincode` failed: {0}")]
+    Bincode(#[from] bincode::Error),
+    #[error("Invalid base proof length {0}, expected 1")]
+    InvalidBaseProofLength(usize),
+    #[error("Invalid public values length {0}, expected at least 32")]
+    InvalidPublicValuesLength(usize),
+    #[error("First 32 public values are expected in byte")]
+    InvalidPublicValues,
+    #[error("Public values digest are expected in bytes")]
+    InvalidPublicValuesDigest,
 }

--- a/tests/pico/stock_nightly_no_std/src/pico_rt.rs
+++ b/tests/pico/stock_nightly_no_std/src/pico_rt.rs
@@ -31,7 +31,6 @@ fn __start(_argc: isize, _argv: *const *const u8) -> isize {
     main();
 
     syscall_halt(0);
-    unreachable!()
 }
 
 /// Halts the program with the given exit code.


### PR DESCRIPTION
This PR:

- Copy and modify the client from https://github.com/brevis-network/pico/blob/v1.1.7/sdk/sdk/src/client.rs and remove the groth16 wrapper
- Add `PicoProofWithPublicValues` because the public values of recursive proof only contains digest of guest public values.
- Check public values digest matches in method `verify`, and returns public values from `PicoProofWithPublicValues`

This should unblock https://github.com/eth-act/zkevm-benchmark-workload/issues/173