### PR TITLE
zisk: add memlock unlimited

### DIFF
--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -420,6 +420,7 @@ impl zkVM for EreDockerizedzkVM {
             // requires at least 8G shared memory, here we set 16G for safety.
             ErezkVM::Zisk => cmd
                 .option("shm-size", "16G")
+                .option("ulimit", "memlock=-1:-1")
                 .inherit_env("ZISK_PREALLOCATE")
                 .inherit_env("ZISK_UNLOCK_MAPPED_MEMORY")
                 .inherit_env("ZISK_MINIMAL_MEMORY")


### PR DESCRIPTION
Fix for the need for `ZISK_UNLOCK_MAPPED_MEMORY=1`.

Related:
- https://github.com/eth-act/zkevm-benchmark-workload/pull/188
- https://github.com/eth-act/ere/issues/134
- https://github.com/eth-act/ere/pull/137

I'll leave this in draft until I run it in more mainnet blocks for extra double-checking, in case it creates any other problems (but that would be surprising, though).