### PR TITLE
Include OpenVM execution cycles count

### DIFF
--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -111,15 +111,16 @@ impl zkVM for EreOpenVM {
         serialize_inputs(&mut stdin, inputs);
 
         let start = Instant::now();
-        let public_values = self
+        let (public_values, (_cost, cycles)) = self
             .cpu_sdk()?
-            .execute(self.app_exe.clone(), stdin)
+            .execute_metered_cost(self.app_exe.clone(), stdin)
             .map_err(|e| OpenVMError::from(ExecuteError::Execute(e)))?;
 
         Ok((
             public_values,
             ProgramExecutionReport {
                 execution_duration: start.elapsed(),
+                total_num_cycles: cycles,
                 ..Default::default()
             },
         ))


### PR DESCRIPTION
Switch from [`CpuSdk::execute`](https://github.com/openvm-org/openvm/blob/39ee587f0f73646e3753cb2aa5f34885d4efffe0/crates/sdk/src/lib.rs#L345) to [`CpuSdk::execute_metered_cost`](https://github.com/openvm-org/openvm/blob/39ee587f0f73646e3753cb2aa5f34885d4efffe0/crates/sdk/src/lib.rs#L396) in order to get the execution cycles along with public values.