### PR TITLE
ere-dockerized: avoid blocking worker threads

### DIFF
--- a/crates/ere-dockerized/src/lib.rs
+++ b/crates/ere-dockerized/src/lib.rs
@@ -518,7 +518,7 @@ impl zkVM for EreDockerizedzkVM {
 
 fn block_on<T>(future: impl Future<Output = T>) -> T {
     match tokio::runtime::Handle::try_current() {
-        Ok(handle) => handle.block_on(future),
+        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(future)),
         Err(_) => tokio::runtime::Runtime::new().unwrap().block_on(future),
     }
 }


### PR DESCRIPTION
When using `ere` from a Tokio environment ([workload integration tests](https://github.com/eth-act/zkevm-benchmark-workload/blob/046ad63f60c59e6e1883231094a151be0cd6952e/tests/src/stateless_validator.rs#L19)), we get [this error](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/18383344370/job/52375450241?pr=204#step:7:1748):
```
[sp1]     Compiling reth-evm-ethereum v1.8.1 (https://github.com/kevaundray/reth?rev=bb7a98e4f9a173d19e2e218126e9bfe344201b8d#bb7a98e4)
[sp1]     Compiling sparsestate v0.1.0 (https://github.com/eth-act/zkvm-ethereum-mpt.git?tag=v0.1.0#f7e1ec1a)
[sp1]     Compiling ere-reth-guest v0.1.0 (/guest/stateless-validator/reth/guest)
[sp1]     Compiling reth-sp1-stateless-validator v0.1.0 (/guest/stateless-validator/reth/sp1)
[sp1]      Finished `release` profile [optimized] target(s) in 1m 15s
cargo:rustc-env=SP1_ELF_reth-sp1-stateless-validator=/guest/target/elf-compilation/riscv32im-succinct-zkvm-elf/release/reth-sp1-stateless-validator
FAILED

failures:

---- stateless_validator::tests::execute_mainnet_blocks stdout ----

thread 'stateless_validator::tests::execute_mainnet_blocks' (24458) panicked at /data/gh-home/.cargo/git/checkouts/ere-53ff6597ed529537/6449699/crates/ere-dockerized/src/lib.rs:521:30:
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    stateless_validator::tests::execute_mainnet_blocks

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 7 filtered out; finished in 150.10s
```

The reason is that in workload tests we use Tokio, but the way ere is blocking here isn't allowed by Tokio -- it doesn't allow blocking worker threads. This change should block it, but spawn a new one so Tokio is happy with not blocking any other potential async tasks.
