### PR TITLE
sp1: add clang dep

### DIFF
--- a/docker/sp1/Dockerfile.compiler
+++ b/docker/sp1/Dockerfile.compiler
@@ -17,6 +17,7 @@ FROM $RUNTIME_IMAGE AS runtime_stage
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
+    clang \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy Rust


### PR DESCRIPTION
I was testing the latest ere version in workload, and [got this problem](https://github.com/eth-act/zkevm-benchmark-workload/actions/runs/18388019342/job/52395277859?pr=204#step:7:1626).

I think with the latest big changes a PR I did a while ago got lost (https://github.com/eth-act/ere/pull/119).