### PR TITLE
OpenVM execution no metering

### DIFF
--- a/crates/ere-openvm/src/lib.rs
+++ b/crates/ere-openvm/src/lib.rs
@@ -111,16 +111,15 @@ impl zkVM for EreOpenVM {
         serialize_inputs(&mut stdin, inputs);
 
         let start = Instant::now();
-        let (public_values, (_cost, cycles)) = self
+        let public_values = self
             .cpu_sdk()?
-            .execute_metered_cost(self.app_exe.clone(), stdin)
+            .execute(self.app_exe.clone(), stdin)
             .map_err(|e| OpenVMError::from(ExecuteError::Execute(e)))?;
 
         Ok((
             public_values,
             ProgramExecutionReport {
                 execution_duration: start.elapsed(),
-                total_num_cycles: cycles,
                 ..Default::default()
             },
         ))


### PR DESCRIPTION
This PR reverts #158 to avoid the situation that hits the [`DEFAULT_MAX_COST`](https://github.com/openvm-org/openvm/blob/b8049235ff9715c871333fe91f5a5b60f5993d0c/crates/vm/src/arch/execution_mode/metered_cost.rs#L15C11-L15C27) and [`should_suspend`](https://github.com/openvm-org/openvm/blob/b8049235ff9715c871333fe91f5a5b60f5993d0c/crates/vm/src/arch/execution_mode/metered_cost.rs#L126-L134) returns `true` so the program is not fully executed. And in SDK it seems there is no way to configure the `max_execution_cost` without inlining the `execute_metered_cost` method.

Resolves #165 