### PR TITLE
Fix ZisK server recovering

### DIFF
--- a/crates/zkvm/zisk/src/zkvm.rs
+++ b/crates/zkvm/zisk/src/zkvm.rs
@@ -47,6 +47,8 @@ impl EreZisk {
             // Recreate the server if it has been created but failed to get status.
             Some(s) => {
                 if s.status().is_err() {
+                    // Drop server first to make sure the server is shutdown.
+                    drop(server.take());
                     *server = Some(self.sdk.server()?);
                 }
             }


### PR DESCRIPTION
Previously we recover the server by recreating, but because the `drop` is not explictly done before recreating, the `cargo-zisk prove-client shutdown` command is done after we create the new server, which makes the following `prove` fail to connect to the server.

Resolves #212