### PR TITLE
Add `print` and `cycle_scope` methods for `Platform`

### DIFF
--- a/crates/zkvm-interface/platform/src/lib.rs
+++ b/crates/zkvm-interface/platform/src/lib.rs
@@ -8,13 +8,44 @@ pub mod output_hasher;
 
 /// Platform dependent methods.
 pub trait Platform {
-    /// Read the whole input at once from host.
+    /// Reads the whole input at once from host.
     ///
     /// Note that this function should only be called once.
     fn read_whole_input() -> Vec<u8>;
 
-    /// Write the whole output at once to host.
+    /// Writes the whole output at once to host.
     ///
     /// Note that this function should only be called once.
     fn write_whole_output(output: &[u8]);
+
+    /// Prints a message to the host environment.
+    ///
+    /// Note that this function will be a no-op if the platform doesn't support.
+    fn print(message: &str);
+
+    /// Returns the current cycle count.
+    ///
+    /// Note that this function will return `None` if the platform doesn't support.
+    fn cycle_count() -> Option<u64> {
+        None
+    }
+
+    /// Enters a cycle scope of `name`.
+    ///
+    /// Note that this function will be a no-op if the platform doesn't support.
+    fn cycle_scope_start(_name: &str) {}
+
+    /// Exits a cycle scope of `name`.
+    ///
+    /// Note that this function will be a no-op if the platform doesn't support.
+    fn cycle_scope_end(_name: &str) {}
+
+    /// Runs a given function `f` within a cycle scope `name`.
+    ///
+    /// Note that this function will be a no-op if the platform doesn't support.
+    fn cycle_scope(name: &str, f: impl Fn()) {
+        Self::cycle_scope_start(name);
+        f();
+        Self::cycle_scope_end(name);
+    }
 }

--- a/crates/zkvm/airbender/platform/src/lib.rs
+++ b/crates/zkvm/airbender/platform/src/lib.rs
@@ -29,4 +29,9 @@ impl<H: FixedOutputHasher<OutputSize = U32>> Platform for AirbenderPlatform<H> {
         let words = array::from_fn(|i| u32::from_le_bytes(array::from_fn(|j| hash[4 * i + j])));
         riscv_common::zksync_os_finish_success(&words);
     }
+
+    fn print(message: &str) {
+        #[cfg(feature = "uart")]
+        core::fmt::Write::write_str(&mut riscv_common::QuasiUART::new(), message).unwrap();
+    }
 }

--- a/crates/zkvm/jolt/platform/src/lib.rs
+++ b/crates/zkvm/jolt/platform/src/lib.rs
@@ -89,4 +89,8 @@ impl<C: JoltMemoryConfig, H: OutputHasher> Platform for JoltPlatform<C, H> {
         let output_slice = unsafe { core::slice::from_raw_parts_mut(output_ptr, max_output_len) };
         jolt::postcard::to_slice(&*hash, output_slice).unwrap();
     }
+
+    fn print(message: &str) {
+        jolt::print(message);
+    }
 }

--- a/crates/zkvm/nexus/platform/src/lib.rs
+++ b/crates/zkvm/nexus/platform/src/lib.rs
@@ -23,4 +23,8 @@ impl<H: OutputHasher> Platform for NexusPlatform<H> {
         let hash = H::output_hash(output);
         nexus_rt::write_public_output(&*hash).unwrap()
     }
+
+    fn print(message: &str) {
+        nexus_rt::print!("{message}")
+    }
 }

--- a/crates/zkvm/openvm/platform/src/lib.rs
+++ b/crates/zkvm/openvm/platform/src/lib.rs
@@ -23,4 +23,8 @@ impl<H: FixedOutputHasher<OutputSize = U32>> Platform for OpenVMPlatform<H> {
         let hash = H::output_hash(output).deref().try_into().unwrap();
         openvm::io::reveal_bytes32(hash);
     }
+
+    fn print(message: &str) {
+        openvm::io::print(message)
+    }
 }

--- a/crates/zkvm/pico/platform/src/lib.rs
+++ b/crates/zkvm/pico/platform/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 use core::marker::PhantomData;
 use ere_platform_trait::output_hasher::OutputHasher;
 
@@ -21,6 +21,19 @@ impl<H: OutputHasher> Platform for PicoPlatform<H> {
 
     fn write_whole_output(output: &[u8]) {
         let hash = H::output_hash(output);
-        pico_sdk::io::commit_bytes(&*hash);
+        pico_sdk::io::commit_bytes(&hash);
+    }
+
+    fn print(message: &str) {
+        let bytes = message.as_bytes();
+        pico_sdk::riscv_ecalls::sys_write(1, bytes.as_ptr(), bytes.len());
+    }
+
+    fn cycle_scope_start(name: &str) {
+        Self::print(&format!("cycle-tracker-start: {name}"))
+    }
+
+    fn cycle_scope_end(name: &str) {
+        Self::print(&format!("cycle-tracker-end: {name}"))
     }
 }

--- a/crates/zkvm/risc0/platform/src/lib.rs
+++ b/crates/zkvm/risc0/platform/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 use ere_platform_trait::output_hasher::OutputHasher;
+use risc0_zkvm::guest::env::Write;
 
 pub use ere_platform_trait::{
     Platform,
@@ -28,6 +29,14 @@ impl<H: OutputHasher> Platform for Risc0Platform<H> {
 
     fn write_whole_output(output: &[u8]) {
         let hash = H::output_hash(output);
-        risc0_zkvm::guest::env::commit_slice(&*hash);
+        risc0_zkvm::guest::env::commit_slice(&hash);
+    }
+
+    fn print(message: &str) {
+        risc0_zkvm::guest::env::stdout().write_slice(message.as_bytes());
+    }
+
+    fn cycle_count() -> Option<u64> {
+        Some(risc0_zkvm::guest::env::cycle_count())
     }
 }

--- a/crates/zkvm/sp1/platform/src/lib.rs
+++ b/crates/zkvm/sp1/platform/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 use core::marker::PhantomData;
 use ere_platform_trait::output_hasher::OutputHasher;
 
@@ -21,6 +21,19 @@ impl<H: OutputHasher> Platform for SP1Platform<H> {
 
     fn write_whole_output(output: &[u8]) {
         let hash = H::output_hash(output);
-        sp1_zkvm::io::commit_slice(&*hash);
+        sp1_zkvm::io::commit_slice(&hash);
+    }
+
+    fn print(message: &str) {
+        let bytes = message.as_bytes();
+        sp1_zkvm::syscalls::sys_write(1, bytes.as_ptr(), bytes.len());
+    }
+
+    fn cycle_scope_start(name: &str) {
+        Self::print(&format!("cycle-tracker-report-start: {name}"))
+    }
+
+    fn cycle_scope_end(name: &str) {
+        Self::print(&format!("cycle-tracker-report-end: {name}"))
     }
 }

--- a/crates/zkvm/ziren/platform/src/lib.rs
+++ b/crates/zkvm/ziren/platform/src/lib.rs
@@ -21,6 +21,11 @@ impl<H: OutputHasher> Platform for ZirenPlatform<H> {
 
     fn write_whole_output(output: &[u8]) {
         let hash = H::output_hash(output);
-        zkm_zkvm::io::commit_slice(&*hash);
+        zkm_zkvm::io::commit_slice(&hash);
+    }
+
+    fn print(message: &str) {
+        let bytes = message.as_bytes();
+        zkm_zkvm::syscalls::sys_write(1, bytes.as_ptr(), bytes.len());
     }
 }

--- a/crates/zkvm/zisk/platform/src/lib.rs
+++ b/crates/zkvm/zisk/platform/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use ere_platform_trait::output_hasher::FixedOutputHasher;
+use ziskos::ziskos_definitions::ziskos_config::UART_ADDR;
 
 pub use ere_platform_trait::{
     Platform,
@@ -24,5 +25,14 @@ impl<H: FixedOutputHasher<OutputSize = U32>> Platform for ZiskPlatform<H> {
         hash.chunks_exact(4).enumerate().for_each(|(idx, bytes)| {
             ziskos::set_output(idx, u32::from_le_bytes(bytes.try_into().unwrap()))
         });
+    }
+
+    fn print(message: &str) {
+        let bytes = message.as_bytes();
+        for i in 0..bytes.len() {
+            unsafe {
+                core::ptr::write_volatile(UART_ADDR as *mut u8, bytes[i]);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR extends the `Platform` for `zkevm-benchmark-workload` guest usage.