### PR TITLE
Revert the `untagged` derive

### DIFF
--- a/crates/zkvm-interface/src/zkvm/resource.rs
+++ b/crates/zkvm-interface/src/zkvm/resource.rs
@@ -26,7 +26,7 @@ impl NetworkProverConfig {
 
 /// ResourceType specifies what resource will be used to create the proofs.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged, rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::Subcommand))]
 pub enum ProverResourceType {
     #[default]


### PR DESCRIPTION
Turns out untagged unit variant is not supported by toml and yaml, reverting the change did in #250 (was testing the wrong revision and thought it works 🙏)
