### PR TITLE
Bump workspace version to `v0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "ere-airbender"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3814,14 +3814,14 @@ dependencies = [
 
 [[package]]
 name = "ere-build-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo_metadata 0.19.2",
 ]
 
 [[package]]
 name = "ere-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-build-utils",
  "serde",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "ere-compile-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "ere-compiler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "ere-dockerized"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ere-common",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "ere-io"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode 2.0.1",
  "ciborium",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "ere-jolt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ark-serialize 0.5.0",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "ere-miden"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ere-build-utils",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "ere-nexus"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "ere-openvm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ere-build-utils",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "ere-pico"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "riscv_common",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-jolt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "jolt-sdk",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-nexus"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "nexus-rt",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "openvm",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-pico"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "pico-sdk",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "risc0-zkvm",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "sp1-zkvm",
@@ -4046,14 +4046,14 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-trait"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "ere-platform-ziren"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "zkm-zkvm",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-platform-trait",
  "ziskos",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "ere-risc0"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "ere-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "ere-sp1"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "ere-test-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "ere-ziren"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zisk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zkvm-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Then we can release `v0.2.0` and use the new `ere-compiler` feature on `ere-guests` repo
