### PR TITLE
Skip `jolt` in workflow `check-zkvm-version.yml`

### DIFF
--- a/.github/workflows/check-zkvm-version.yml
+++ b/.github/workflows/check-zkvm-version.yml
@@ -19,8 +19,9 @@ jobs:
         include:
           - zkvm: airbender
             crate: execution_utils
-          - zkvm: jolt
-            crate: jolt-sdk
+          # Skip jolt because we are using a specific revision instead of released tag
+          # - zkvm: jolt
+          #   crate: jolt-sdk
           - zkvm: miden
             crate: miden-core
           - zkvm: nexus


### PR DESCRIPTION
Becasue we are using a specific revision instead of released tag.