### PR TITLE
Bump workspace version to `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "ere-airbender"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3771,14 +3771,14 @@ dependencies = [
 
 [[package]]
 name = "ere-build-utils"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "cargo_metadata 0.19.2",
 ]
 
 [[package]]
 name = "ere-common"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-build-utils",
  "serde",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "ere-compile-utils"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "ere-compiler"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "ere-dockerized"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ere-common",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "ere-io"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "bincode 2.0.1",
  "ciborium",
@@ -3847,7 +3847,7 @@ dependencies = [
 
 [[package]]
 name = "ere-jolt"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ark-serialize 0.5.0",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "ere-openvm"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ere-build-utils",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "ere-pico"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-platform-trait",
  "riscv_common",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-jolt"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "common",
  "ere-platform-trait",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-platform-trait",
  "openvm",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-pico"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-platform-trait",
  "pico-sdk",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-platform-trait",
  "risc0-zkvm",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-platform-trait",
  "sp1-zkvm",
@@ -3959,14 +3959,14 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-trait"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-platform-trait",
  "fnv",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "ere-risc0"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "ere-server"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "ere-sp1"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "ere-test-utils"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zisk"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zkvm-interface"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
For next release `v0.5.0`.

(note that release `v0.4.0` exists but the workspace version is left `0.3.0` by mistake) 
