### PR TITLE
Propagate `ziskos` features in `ere-platform-zisk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69dde51e8fef5e12c1d65e0929b03d66e4c0c18282bc30ed2ca050ad6f44dd82"
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f5b01c17f85ee988d832c40e549a64bd89ab2c9f8d8a613bdf5122ae507e294"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "docker-generate"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13308,6 +13319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "talc"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15682,7 +15702,10 @@ dependencies = [
  "bincode 1.3.3",
  "bytes",
  "cfg-if",
+ "critical-section",
  "ctor 0.2.9",
+ "dlmalloc",
+ "embedded-alloc",
  "fields 0.16.0 (git+https://github.com/0xPolygonHermez/pil2-proofman.git?branch=pre-develop-0.16.0)",
  "getrandom 0.2.16",
  "lazy_static",
@@ -15696,6 +15719,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2",
+ "talc",
  "tiny-keccak",
  "tokio",
  "zisk-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,9 +124,8 @@ sp1-sdk = "6.0.1"
 sp1-p3-field = { version = "0.3.2-succinct", package = "p3-field" }
 sp1-zkvm = { version = "6.0.1", default-features = false }
 
-
 # ZisK dependencies
-ziskos = { git = "https://github.com/han0110/zisk.git", branch = "patch/v0.16.0" }
+ziskos = { git = "https://github.com/han0110/zisk.git", branch = "patch/v0.16.0", default-features = false }
 zisk-rom-setup = { git = "https://github.com/han0110/zisk.git", branch = "patch/v0.16.0", package = "rom-setup" }
 zisk-sdk = { git = "https://github.com/han0110/zisk.git", branch = "patch/v0.16.0" }
 zisk-core = { git = "https://github.com/han0110/zisk.git", branch = "patch/v0.16.0" }

--- a/crates/zkvm/zisk/platform/Cargo.toml
+++ b/crates/zkvm/zisk/platform/Cargo.toml
@@ -16,7 +16,14 @@ fnv.workspace = true
 ere-platform-trait.workspace = true
 
 [features]
-default = []
+default = ["user-hints", "inputcpy"]
+user-hints = ["ziskos/user-hints"]
+inputcpy = ["ziskos/inputcpy"]
+zisk-custom-alloc = ["ziskos/zisk-custom-alloc"]
+zisk-embedded-alloc = ["ziskos/zisk-embedded-alloc"]
+zisk-embedded-dlmalloc-alloc = ["ziskos/zisk-embedded-dlmalloc-alloc"]
+zisk-embedded-talc-alloc = ["ziskos/zisk-embedded-talc-alloc"]
+zisk-embedded-tlfs-alloc = ["ziskos/zisk-embedded-tlfs-alloc"]
 check-cycle-scope = []
 
 [lints]


### PR DESCRIPTION
So the guest can turn off the default features of `ziskos` when needed (just found out the default features include many stuff when update `ere-guests`...)

The features are propagated as is, see https://github.com/0xPolygonHermez/zisk/blob/v0.16.0/ziskos/entrypoint/Cargo.toml#L50-L58