### PR TITLE
Bump workspace version to `0.6.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "ere-airbender"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3664,14 +3664,14 @@ dependencies = [
 
 [[package]]
 name = "ere-build-utils"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "cargo_metadata 0.19.2",
 ]
 
 [[package]]
 name = "ere-common"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-build-utils",
  "serde",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "ere-compile-utils"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.19.2",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "ere-compiler"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "ere-dockerized"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ere-common",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "ere-io"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bincode 2.0.1",
  "ciborium",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "ere-openvm"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ere-build-utils",
@@ -3759,7 +3759,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-platform-trait",
  "riscv_common",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-platform-trait",
  "openvm",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-platform-trait",
  "risc0-zkvm",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-platform-trait",
  "sp1-zkvm",
@@ -3792,14 +3792,14 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-trait"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-platform-trait",
  "fnv",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "ere-risc0"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "ere-server"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "ere-sp1"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "ere-test-utils"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zisk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "ere-zkvm-interface"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Previous `0.5.1` should be removed, since there are more commits other than just update zisk from `v0.16.0` to `v0.16.1`, will try to use CI tomake the release routine automatically in a following PR to avoid this..