### PR TITLE
fix: update zisk patch rev to `75957ca` with fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "asm-runner"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "libc",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 
 [[package]]
 name = "circuit_common"
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "data-bus"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "zisk-common",
  "zisk-core",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "executor"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "asm-runner",
@@ -5471,12 +5471,12 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib-c"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 
 [[package]]
 name = "lib-float"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 
 [[package]]
 name = "lib-rv32-asm"
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "mem-common"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "clap",
  "fields",
@@ -5810,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "mem-planner-cpp"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "mem-common",
  "proofman-common",
@@ -8397,7 +8397,7 @@ dependencies = [
 [[package]]
 name = "precomp-arith-eq"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
@@ -8434,7 +8434,7 @@ dependencies = [
 [[package]]
 name = "precomp-arith-eq-384"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8471,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "precomp-big-int"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "generic-array 0.14.9",
@@ -8493,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "precomp-blake2"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "mem-common",
@@ -8513,7 +8513,7 @@ dependencies = [
 [[package]]
 name = "precomp-dma"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "generic-array 0.14.9",
@@ -8537,7 +8537,7 @@ dependencies = [
 [[package]]
 name = "precomp-keccakf"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "circuit",
  "fields",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "precomp-poseidon2"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "mem-common",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "precomp-sha256f"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "mem-common",
@@ -8600,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "precompiles-common"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "mem-common",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "precompiles-helpers"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -8630,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "precompiles-hints"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "borsh",
@@ -9975,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "riscv"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 
 [[package]]
 name = "riscv_common"
@@ -10038,7 +10038,7 @@ dependencies = [
 [[package]]
 name = "rom-setup"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "blake3",
@@ -11356,7 +11356,7 @@ dependencies = [
 [[package]]
 name = "sm-arith"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "num-bigint 0.4.6",
@@ -11377,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "sm-binary"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "num-bigint 0.4.6",
@@ -11397,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "sm-frequent-ops"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "clap",
  "fields",
@@ -11413,7 +11413,7 @@ dependencies = [
 [[package]]
 name = "sm-main"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "mem-common",
@@ -11433,7 +11433,7 @@ dependencies = [
 [[package]]
 name = "sm-mem"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "mem-common",
@@ -11454,7 +11454,7 @@ dependencies = [
 [[package]]
 name = "sm-rom"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "asm-runner",
  "fields",
@@ -14579,7 +14579,7 @@ dependencies = [
 [[package]]
 name = "zisk-build"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",
@@ -14592,7 +14592,7 @@ dependencies = [
 [[package]]
 name = "zisk-common"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -14617,7 +14617,7 @@ dependencies = [
 [[package]]
 name = "zisk-core"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "elf",
  "fields",
@@ -14637,12 +14637,12 @@ dependencies = [
 [[package]]
 name = "zisk-definitions"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 
 [[package]]
 name = "zisk-distributed-common"
 version = "0.1.0"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "borsh",
@@ -14663,7 +14663,7 @@ dependencies = [
 [[package]]
 name = "zisk-distributed-grpc-api"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "chrono",
@@ -14682,7 +14682,7 @@ dependencies = [
 [[package]]
 name = "zisk-pil"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "fields",
  "proofman-common",
@@ -14695,7 +14695,7 @@ dependencies = [
 [[package]]
 name = "zisk-sdk"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "asm-runner",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "zisk-verifier"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "proofman-verifier",
 ]
@@ -14730,7 +14730,7 @@ dependencies = [
 [[package]]
 name = "ziskemu"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "clap",
  "data-bus",
@@ -14757,7 +14757,7 @@ dependencies = [
 [[package]]
 name = "ziskos"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -14791,7 +14791,7 @@ dependencies = [
 [[package]]
 name = "ziskos-hints"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#75957ca082715ca9655f178630a2a4e90fe0b466"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",


### PR DESCRIPTION
The rev contains a fix to [enable some missed feature](https://github.com/han0110/zisk/commit/75957ca082715ca9655f178630a2a4e90fe0b466) when proving with gpu. Resolves #320.