### PR TITLE
feat: update `risc0` to `v3.0.5` and use its latset rust release

### DIFF
--- a/.github/workflows/test-zkvm.yml
+++ b/.github/workflows/test-zkvm.yml
@@ -158,7 +158,7 @@ jobs:
             --zkvm ${{ inputs.zkvm }} \
             --registry ${{ needs.image_meta.outputs.image_registry }} \
             --tag ${{ needs.image_meta.outputs.image_tag }} \
-            --cached-tag ${{ needs.image_meta.outputs.cached_image_tag }}
+            --cached-tag "${{ needs.image_meta.outputs.cached_image_tag }}"
 
       - name: Run cargo clippy for ere-${{ inputs.zkvm }} via Docker
         run: |
@@ -215,7 +215,7 @@ jobs:
             --zkvm ${{ inputs.zkvm }} \
             --registry ${{ needs.image_meta.outputs.image_registry }} \
             --tag ${{ needs.image_meta.outputs.image_tag }} \
-            --cached-tag ${{ needs.image_meta.outputs.cached_image_tag }}
+            --cached-tag "${{ needs.image_meta.outputs.cached_image_tag }}"
 
       - name: Increase swap to 8GB
         run: |
@@ -290,7 +290,7 @@ jobs:
             --zkvm ${{ inputs.zkvm }} \
             --registry ${{ needs.image_meta.outputs.image_registry }} \
             --tag ${{ needs.image_meta.outputs.image_tag }} \
-            --cached-tag ${{ needs.image_meta.outputs.cached_image_tag }}
+            --cached-tag "${{ needs.image_meta.outputs.cached_image_tag }}"
 
           # Build ere-compiler-${{ inputs.zkvm }} and ere-server-${{ inputs.zkvm }}
           bash .github/scripts/build-image.sh \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,11 +95,11 @@ openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v
 openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.3", default-features = false }
 
 # Risc0 dependencies
-risc0-binfmt = { version = "3.0.3", default-features = false }
-risc0-build = "3.0.4"
-risc0-zkp = { version = "3.0.3", default-features = false }
-risc0-zkvm = { version = "3.0.4", default-features = false }
-risc0-zkvm-platform = { version = "2.2.1", default-features = false }
+risc0-binfmt = { version = "3.0.4", default-features = false }
+risc0-build = "3.0.5"
+risc0-zkp = { version = "3.0.4", default-features = false }
+risc0-zkvm = { version = "3.0.5", default-features = false }
+risc0-zkvm-platform = { version = "2.2.2", default-features = false }
 
 # SP1 dependencies
 sp1-cuda = "6.0.1"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ OutputHashedPlatform::<OpenVMPlatform, Sha256>::write_whole_output(&large_output
 | --------- | ---------------------------------------------------------------------- | --------- | :---: | :-------: | :-----: |
 | Airbender | [`0.5.2`](https://github.com/matter-labs/zksync-airbender/tree/v0.5.2) | `RV32IMA` |   V   |     V     |         |
 | OpenVM    | [`1.4.3`](https://github.com/openvm-org/openvm/tree/v1.4.3)            | `RV32IMA` |   V   |           |         |
-| Risc0     | [`3.0.4`](https://github.com/risc0/risc0/tree/v3.0.4)                  | `RV32IMA` |   V   |     V     |         |
+| Risc0     | [`3.0.5`](https://github.com/risc0/risc0/tree/v3.0.5)                  | `RV32IMA` |   V   |     V     |         |
 | SP1       | [`6.0.1`](https://github.com/succinctlabs/sp1/tree/v6.0.1)             | `RV64IMA` |   V   |           |         |
 | Zisk      | [`0.16.1`](https://github.com/0xPolygonHermez/zisk/tree/v0.16.1)       | `RV64IMA` |   V   |     V     |    V    |
 

--- a/crates/zkvm/risc0/src/compiler/rust_rv32ima.rs
+++ b/crates/zkvm/risc0/src/compiler/rust_rv32ima.rs
@@ -6,10 +6,10 @@ use std::{env, path::Path};
 use tracing::info;
 
 // TODO: Make this with `zkos` package building to avoid binary file storing in repo.
-// File taken from https://github.com/risc0/risc0/blob/v3.0.4/risc0/zkos/v1compat/elfs/v1compat.elf
+// File taken from https://github.com/risc0/risc0/blob/v3.0.5/risc0/zkos/v1compat/elfs/v1compat.elf
 const V1COMPAT_ELF: &[u8] = include_bytes!("rust_rv32ima/v1compat.elf");
 const TARGET_TRIPLE: &str = "riscv32ima-unknown-none-elf";
-// Rust flags according to https://github.com/risc0/risc0/blob/v3.0.4/risc0/build/src/lib.rs#L455
+// Rust flags according to https://github.com/risc0/risc0/blob/v3.0.5/risc0/build/src/lib.rs#L455
 const RUSTFLAGS: &[&str] = &[
     "-C",
     "passes=lower-atomic", // Only for rustc > 1.81

--- a/crates/zkvm/risc0/src/zkvm.rs
+++ b/crates/zkvm/risc0/src/zkvm.rs
@@ -18,7 +18,7 @@ include!(concat!(env!("OUT_DIR"), "/name_and_sdk_version.rs"));
 
 /// Default logarithmic segment size from [`DEFAULT_SEGMENT_LIMIT_PO2`].
 ///
-/// [`DEFAULT_SEGMENT_LIMIT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.4/risc0/circuit/rv32im/src/execute/mod.rs#L39.
+/// [`DEFAULT_SEGMENT_LIMIT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.5/risc0/circuit/rv32im/src/execute/mod.rs#L39.
 const DEFAULT_SEGMENT_PO2: usize = 20;
 
 /// Supported range of logarithmic segment size.
@@ -28,18 +28,18 @@ const DEFAULT_SEGMENT_PO2: usize = 20;
 /// The maximum is by [`DEFAULT_MAX_PO2`], although the real maximum is `24`,
 /// but it requires us to set the `control_ids` manually in the `ProverOpts`.
 ///
-/// [`MIN_LIFT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.4/risc0/circuit/recursion/src/control_id.rs#L19
-/// [`DEFAULT_MAX_PO2`]: https://github.com/risc0/risc0/blob/v3.0.4/risc0/zkvm/src/receipt.rs#L884
+/// [`MIN_LIFT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.5/risc0/circuit/recursion/src/control_id.rs#L19
+/// [`DEFAULT_MAX_PO2`]: https://github.com/risc0/risc0/blob/v3.0.5/risc0/zkvm/src/receipt.rs#L898
 const SEGMENT_PO2_RANGE: RangeInclusive<usize> = 14..=DEFAULT_MAX_PO2;
 
 /// Default logarithmic keccak size from [`KECCAK_DEFAULT_PO2`].
 ///
-/// [`KECCAK_DEFAULT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.4/risc0/circuit/keccak/src/lib.rs#L27.
+/// [`KECCAK_DEFAULT_PO2`]: https://github.com/risc0/risc0/blob/v3.0.5/risc0/circuit/keccak/src/lib.rs#L27.
 const DEFAULT_KECCAK_PO2: usize = 17;
 
 /// Supported range of logarithmic keccak size from [`KECCAK_PO2_RANGE`].
 ///
-/// [`KECCAK_PO2_RANGE`]: https://github.com/risc0/risc0/blob/v3.0.4/risc0/circuit/keccak/src/lib.rs#L29.
+/// [`KECCAK_PO2_RANGE`]: https://github.com/risc0/risc0/blob/v3.0.5/risc0/circuit/keccak/src/lib.rs#L29.
 const KECCAK_PO2_RANGE: RangeInclusive<usize> = 14..=18;
 
 pub struct EreRisc0 {

--- a/docker/risc0/Dockerfile.base
+++ b/docker/risc0/Dockerfile.base
@@ -20,9 +20,9 @@ ARG NVCC_APPEND_FLAGS="--generate-code arch=compute_120,code=sm_120"
 COPY --chmod=755 scripts/sdk_installers/install_risc0_sdk.sh /tmp/install_risc0_sdk.sh
 
 # The install_risc0_sdk.sh script will respect these ENV variables.
-ENV RISC0_VERSION="3.0.4" \
+ENV RISC0_VERSION="3.0.5" \
     RISC0_CPP_VERSION="2024.1.5" \
-    RISC0_RUST_VERSION="1.88.0"
+    RISC0_RUST_VERSION="1.94.1"
 
 # Run the Risc0 SDK installation script
 # It will use the RISC0_VERSION, RISC0_CPP_VERSION and RISC0_RUST_VERSION defined above.

--- a/scripts/sdk_installers/install_risc0_sdk.sh
+++ b/scripts/sdk_installers/install_risc0_sdk.sh
@@ -63,9 +63,9 @@ fi
 # Now that rzup is confirmed to be in PATH for this script, install the Risc0 toolchain
 echo "Running 'rzup install' to install/update Risc0 toolchain..."
 
-RISC0_VERSION="${RISC0_VERSION:-3.0.4}"
+RISC0_VERSION="${RISC0_VERSION:-3.0.5}"
 RISC0_CPP_VERSION="${RISC0_CPP_VERSION:-2024.1.5}"
-RISC0_RUST_VERSION="${RISC0_RUST_VERSION:-1.88.0}"
+RISC0_RUST_VERSION="${RISC0_RUST_VERSION:-1.94.1}"
 
 rzup install cargo-risczero "$RISC0_VERSION"
 rzup install cpp "$RISC0_CPP_VERSION"


### PR DESCRIPTION
The Risc0 deps seem already updated in some cargo update accidentally so there is no `Cargo.lock` changes here, but the Dockerfile and SDK installer script update is the real prover update, that builds/downloads the prover binary with `v3.0.5`