### PR TITLE
fix(zisk): export CUDA_ARCH as CUDA_ARCHS env for cargo build

### DIFF
--- a/docker/zisk/Dockerfile.cluster
+++ b/docker/zisk/Dockerfile.cluster
@@ -57,8 +57,11 @@ ARG CUDA
 # Default to build for RTX 50 series
 ARG CUDA_ARCH=sm_120
 
-# Build binaries
-RUN cargo build --release ${CUDA:+--features gpu}
+# Strip the sm_ prefix and export as CUDA_ARCHS (plural, numeric) which is the
+# env var proofman-starks-lib-c/build.rs reads to generate nvcc -gencode flags.
+# See note in docker/zisk/Dockerfile.server for full rationale.
+RUN CUDA_ARCHS="${CUDA_ARCH#sm_}" \
+    cargo build --release ${CUDA:+--features gpu}
 
 FROM $RUNTIME_IMAGE AS runtime
 FROM $RUNTIME_CUDA_IMAGE AS runtime_cuda

--- a/docker/zisk/Dockerfile.server
+++ b/docker/zisk/Dockerfile.server
@@ -17,7 +17,14 @@ ARG RUSTFLAGS
 # Default to build for RTX 50 series
 ARG CUDA_ARCH=sm_120
 
-RUN cargo build --release --package ere-server --bin ere-server --features zisk${CUDA:+,cuda} \
+# Strip the sm_ prefix and export as CUDA_ARCHS (plural, numeric) which is the
+# env var proofman-starks-lib-c/build.rs reads to generate nvcc -gencode flags.
+# Without this export, CUDA_ARCH is declared-but-unused and the build silently
+# falls back to the committed sm_120 default in pil2-stark's CudaArch.mk,
+# producing an image that fails on any non-sm_120 GPU with CUDA error 209
+# (no kernel image is available for execution on the device).
+RUN CUDA_ARCHS="${CUDA_ARCH#sm_}" \
+    cargo build --release --package ere-server --bin ere-server --features zisk${CUDA:+,cuda} \
     && mkdir bin && mv target/release/ere-server bin/ere-server \
     && cargo clean && rm -rf $CARGO_HOME/registry/
 


### PR DESCRIPTION
## Summary

`ARG CUDA_ARCH=sm_120` in `docker/zisk/Dockerfile.server` (and `Dockerfile.cluster`) is dead plumbing — the ARG is declared but never exported into the `RUN cargo build …` environment, so it has no effect.

As a result, the `--cuda-archs N` flag accepted by `.github/scripts/build-image.sh` is silently ignored for zisk. The build always produces an image whose embedded CUDA kernels target `sm_120` (the committed default in `pil2-stark/src/goldilocks/CudaArch.mk`), regardless of what was requested.

## Symptom

The published `ghcr.io/eth-act/ere/ere-server-zisk:*-cuda` images fail on any GPU that is not compute capability 12.0 (RTX 5090 / consumer Blackwell) with:

```
[CUDA] cudaMemcpyToSymbol(GPU_C_4, …) failed due to:
  no kernel image is available for execution on the device (209)
  at src/goldilocks/src/poseidon2_goldilocks.cu:66
```

This was hit locally on 2× RTX 4090 (`sm_89`) even when `--cuda-archs 89` was explicitly passed to `build-image.sh`.

## Fix

Strip the `sm_` prefix off `CUDA_ARCH` and export it as `CUDA_ARCHS` (plural, numeric) inline on the cargo build command. That env var is what `proofman-starks-lib-c/build.rs` reads to generate the correct `nvcc -gencode` flags.

```diff
-RUN cargo build --release --package ere-server --bin ere-server --features zisk${CUDA:+,cuda} \
+RUN CUDA_ARCHS="${CUDA_ARCH#sm_}" \
+    cargo build --release --package ere-server --bin ere-server --features zisk${CUDA:+,cuda} \
```

Same one-line change in `Dockerfile.cluster`.

## Root cause detail

The committed `pil2-stark/src/goldilocks/CudaArch.mk` hardcodes `CUDA_ARCH = sm_120`. The auto-detect path in `configure.sh` requires `deviceQuery`, which needs a runtime GPU — not available during a Docker build. So without `CUDA_ARCHS` being set, the Makefile falls back to the committed default and silently produces an sm_120 image.

## Verification

Built locally with `build-image.sh --zkvm zisk --tag local-sm89-cuda --base --server --cuda-archs 89` and confirmed via `cuobjdump --list-elf` that all 15 embedded `.cubin` ELF sections in `/ere/bin/ere-server` now report `sm_89`.

Running the resulting image on 2× RTX 4090 via the `ethpandaops/ethereum-package` zkboost stack (EIP-8025 testnet) produced real proofs:

```
zkboost_prove_total{proof_type="reth-zisk", status="success"} 3
zkboost_prove_duration_seconds_sum = 34.47   # ~11.5s per proof
```

## Test plan

- [x] `build-image.sh … --cuda-archs 89` produces an image whose kernels are sm_89 (verified with cuobjdump)
- [x] Resulting image runs on RTX 4090 without CUDA error 209
- [x] End-to-end zkboost + lighthouse + reth pipeline generates and verifies proofs
- [ ] Upstream CI builds cleanly for `--cuda-archs 120` (unchanged default behavior)