### PR TITLE
ci(risc0): pass GITHUB_TOKEN as secret env to fix rzup rate limits

### DIFF
--- a/.github/scripts/build-image.sh
+++ b/.github/scripts/build-image.sh
@@ -179,59 +179,53 @@ if [ -n "$RUSTFLAGS" ]; then
     SERVER_ZKVM_BUILD_ARGS+=(--build-arg "RUSTFLAGS=$RUSTFLAGS")
 fi
 
-# Pass GITHUB_TOKEN as a BuildKit secret if available to prevent rzup rate limits
-SECRET_ARGS=()
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-    SECRET_ARGS=(--secret id=github_token,env=GITHUB_TOKEN)
+# Pass GITHUB_TOKEN to prevent rzup hit github rate limits
+if [ -n "$GITHUB_TOKEN" ] && [ "$ZKVM" = "risc0" ]; then
+    BASE_ZKVM_BUILD_ARGS+=(--secret id=github_token,env=GITHUB_TOKEN)
 fi
 
 # Build images
 
 if [ "$BUILD_BASE" = true ]; then
     echo "Building base image: $BASE_IMAGE"
-    DOCKER_BUILDKIT=1 docker build \
+    docker build \
         --file "docker/Dockerfile.base" \
         --tag "$BASE_IMAGE" \
         "${BASE_BUILD_ARGS[@]}" \
-        "${SECRET_ARGS[@]}" \
         .
 
     echo "Building zkvm base image: $BASE_ZKVM_IMAGE"
-    DOCKER_BUILDKIT=1 docker build \
+    docker build \
         --file "docker/${ZKVM}/Dockerfile.base" \
         --tag "$BASE_ZKVM_IMAGE" \
         "${BASE_ZKVM_BUILD_ARGS[@]}" \
-        "${SECRET_ARGS[@]}" \
         .
 fi
 
 if [ "$BUILD_COMPILER" = true ]; then
     echo "Building zkvm compiler image: $COMPILER_ZKVM_IMAGE"
-    DOCKER_BUILDKIT=1 docker build \
+    docker build \
         --file "docker/${ZKVM}/Dockerfile.compiler" \
         --tag "$COMPILER_ZKVM_IMAGE" \
         "${COMPILER_ZKVM_BUILD_ARGS[@]}" \
-        "${SECRET_ARGS[@]}" \
         .
 fi
 
 if [ "$BUILD_SERVER" = true ]; then
     echo "Building zkvm server image: $SERVER_ZKVM_IMAGE"
-    DOCKER_BUILDKIT=1 docker build \
+    docker build \
         --file "docker/${ZKVM}/Dockerfile.server" \
         --tag "$SERVER_ZKVM_IMAGE" \
         "${SERVER_ZKVM_BUILD_ARGS[@]}" \
-        "${SECRET_ARGS[@]}" \
         .
 fi
 
 if [ "$BUILD_CLUSTER" = true ]; then
     echo "Building zkvm cluster image: $CLUSTER_ZKVM_IMAGE"
-    DOCKER_BUILDKIT=1 docker build \
+    docker build \
         --file "docker/${ZKVM}/Dockerfile.cluster" \
         --tag "$CLUSTER_ZKVM_IMAGE" \
         "${CLUSTER_ZKVM_BUILD_ARGS[@]}" \
-        "${SECRET_ARGS[@]}" \
         .
 fi
 

--- a/.github/scripts/build-image.sh
+++ b/.github/scripts/build-image.sh
@@ -179,48 +179,59 @@ if [ -n "$RUSTFLAGS" ]; then
     SERVER_ZKVM_BUILD_ARGS+=(--build-arg "RUSTFLAGS=$RUSTFLAGS")
 fi
 
+# Pass GITHUB_TOKEN as a BuildKit secret if available to prevent rzup rate limits
+SECRET_ARGS=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    SECRET_ARGS=(--secret id=github_token,env=GITHUB_TOKEN)
+fi
+
 # Build images
 
 if [ "$BUILD_BASE" = true ]; then
     echo "Building base image: $BASE_IMAGE"
-    docker build \
+    DOCKER_BUILDKIT=1 docker build \
         --file "docker/Dockerfile.base" \
         --tag "$BASE_IMAGE" \
         "${BASE_BUILD_ARGS[@]}" \
+        "${SECRET_ARGS[@]}" \
         .
 
     echo "Building zkvm base image: $BASE_ZKVM_IMAGE"
-    docker build \
+    DOCKER_BUILDKIT=1 docker build \
         --file "docker/${ZKVM}/Dockerfile.base" \
         --tag "$BASE_ZKVM_IMAGE" \
         "${BASE_ZKVM_BUILD_ARGS[@]}" \
+        "${SECRET_ARGS[@]}" \
         .
 fi
 
 if [ "$BUILD_COMPILER" = true ]; then
     echo "Building zkvm compiler image: $COMPILER_ZKVM_IMAGE"
-    docker build \
+    DOCKER_BUILDKIT=1 docker build \
         --file "docker/${ZKVM}/Dockerfile.compiler" \
         --tag "$COMPILER_ZKVM_IMAGE" \
         "${COMPILER_ZKVM_BUILD_ARGS[@]}" \
+        "${SECRET_ARGS[@]}" \
         .
 fi
 
 if [ "$BUILD_SERVER" = true ]; then
     echo "Building zkvm server image: $SERVER_ZKVM_IMAGE"
-    docker build \
+    DOCKER_BUILDKIT=1 docker build \
         --file "docker/${ZKVM}/Dockerfile.server" \
         --tag "$SERVER_ZKVM_IMAGE" \
         "${SERVER_ZKVM_BUILD_ARGS[@]}" \
+        "${SECRET_ARGS[@]}" \
         .
 fi
 
 if [ "$BUILD_CLUSTER" = true ]; then
     echo "Building zkvm cluster image: $CLUSTER_ZKVM_IMAGE"
-    docker build \
+    DOCKER_BUILDKIT=1 docker build \
         --file "docker/${ZKVM}/Dockerfile.cluster" \
         --tag "$CLUSTER_ZKVM_IMAGE" \
         "${CLUSTER_ZKVM_BUILD_ARGS[@]}" \
+        "${SECRET_ARGS[@]}" \
         .
 fi
 

--- a/.github/scripts/pull-or-build-base-zkvm-image.sh
+++ b/.github/scripts/pull-or-build-base-zkvm-image.sh
@@ -95,6 +95,5 @@ else
     if [ -n "$CUDA_ARCHS" ]; then
         BUILD_ARGS+=(--cuda-archs "$CUDA_ARCHS")
     fi
-    # GITHUB_TOKEN is passed through environment if set
     "$SCRIPT_DIR/build-image.sh" "${BUILD_ARGS[@]}"
 fi

--- a/.github/scripts/pull-or-build-base-zkvm-image.sh
+++ b/.github/scripts/pull-or-build-base-zkvm-image.sh
@@ -95,5 +95,6 @@ else
     if [ -n "$CUDA_ARCHS" ]; then
         BUILD_ARGS+=(--cuda-archs "$CUDA_ARCHS")
     fi
+    # GITHUB_TOKEN is passed through environment if set
     "$SCRIPT_DIR/build-image.sh" "${BUILD_ARGS[@]}"
 fi

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: Build ere-base and ere-base-${{ matrix.zkvm }} images
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
@@ -70,7 +69,6 @@ jobs:
 
       - name: Build ere-compiler-${{ matrix.zkvm }} and ere-server-${{ matrix.zkvm }} images
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
@@ -117,7 +115,6 @@ jobs:
 
       - name: Build ere-base and ere-base-${{ matrix.zkvm }} images with CUDA enabled
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
@@ -133,7 +130,6 @@ jobs:
 
       - name: Build ere-server-${{ matrix.zkvm }} image with CUDA enabled
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
@@ -175,7 +171,6 @@ jobs:
 
       - name: Build ere-cluster-${{ matrix.zkvm }} image with CUDA enabled
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -54,6 +54,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ere-base and ere-base-${{ matrix.zkvm }} images
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ matrix.zkvm }} \
@@ -66,6 +69,9 @@ jobs:
           docker push ${{ needs.image_meta.outputs.registry }}/ere-base-${{ matrix.zkvm }}:${{ needs.image_meta.outputs.sha_tag }}
 
       - name: Build ere-compiler-${{ matrix.zkvm }} and ere-server-${{ matrix.zkvm }} images
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ matrix.zkvm }} \
@@ -110,6 +116,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ere-base and ere-base-${{ matrix.zkvm }} images with CUDA enabled
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ matrix.zkvm }} \
@@ -123,6 +132,9 @@ jobs:
           docker push ${{ needs.image_meta.outputs.registry }}/ere-base-${{ matrix.zkvm }}:${{ needs.image_meta.outputs.sha_tag }}-cuda
 
       - name: Build ere-server-${{ matrix.zkvm }} image with CUDA enabled
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ matrix.zkvm }} \
@@ -162,6 +174,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ere-cluster-${{ matrix.zkvm }} image with CUDA enabled
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ matrix.zkvm }} \

--- a/.github/workflows/test-zkvm.yml
+++ b/.github/workflows/test-zkvm.yml
@@ -97,6 +97,9 @@ jobs:
         run: bash .github/scripts/free-up-disk-space.sh
 
       - name: Pull or build ere-base and ere-base-${{ inputs.zkvm }} images with CUDA enabled
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CACHED_TAG="${{ needs.image_meta.outputs.cached_image_tag }}"
           if [ -n "$CACHED_TAG" ]; then
@@ -110,6 +113,9 @@ jobs:
             --cuda-archs '${{ env.CUDA_ARCHS }}'
 
       - name: Build ere-server-${{ inputs.zkvm }} image with CUDA enabled
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ inputs.zkvm }} \
@@ -120,6 +126,9 @@ jobs:
 
       - name: Build ere-cluster-${{ inputs.zkvm }} image with CUDA enabled
         if: ${{ inputs.cluster && needs.image_meta.outputs.dockerfile_changed == 'true' }}
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
             --zkvm ${{ inputs.zkvm }} \
@@ -213,6 +222,9 @@ jobs:
 
       - name: Pull base zkvm image or build locally
         if: github.event_name == 'pull_request'
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/pull-or-build-base-zkvm-image.sh \
             --zkvm ${{ inputs.zkvm }} \
@@ -294,6 +306,9 @@ jobs:
 
       - name: Pull images or build locally
         if: github.event_name == 'pull_request'
+        env:
+          DOCKER_BUILDKIT: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/pull-or-build-base-zkvm-image.sh \
             --zkvm ${{ inputs.zkvm }} \

--- a/.github/workflows/test-zkvm.yml
+++ b/.github/workflows/test-zkvm.yml
@@ -98,7 +98,6 @@ jobs:
 
       - name: Pull or build ere-base and ere-base-${{ inputs.zkvm }} images with CUDA enabled
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CACHED_TAG="${{ needs.image_meta.outputs.cached_image_tag }}"
@@ -114,7 +113,6 @@ jobs:
 
       - name: Build ere-server-${{ inputs.zkvm }} image with CUDA enabled
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
@@ -127,7 +125,6 @@ jobs:
       - name: Build ere-cluster-${{ inputs.zkvm }} image with CUDA enabled
         if: ${{ inputs.cluster && needs.image_meta.outputs.dockerfile_changed == 'true' }}
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/build-image.sh \
@@ -162,6 +159,8 @@ jobs:
 
       - name: Pull base zkvm image or build locally
         if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/pull-or-build-base-zkvm-image.sh \
             --zkvm ${{ inputs.zkvm }} \
@@ -223,7 +222,6 @@ jobs:
       - name: Pull base zkvm image or build locally
         if: github.event_name == 'pull_request'
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/pull-or-build-base-zkvm-image.sh \
@@ -307,7 +305,6 @@ jobs:
       - name: Pull images or build locally
         if: github.event_name == 'pull_request'
         env:
-          DOCKER_BUILDKIT: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash .github/scripts/pull-or-build-base-zkvm-image.sh \

--- a/docker/risc0/Dockerfile.base
+++ b/docker/risc0/Dockerfile.base
@@ -24,9 +24,10 @@ ENV RISC0_VERSION="3.0.5" \
     RISC0_CPP_VERSION="2024.1.5" \
     RISC0_RUST_VERSION="1.94.1"
 
-# Run the Risc0 SDK installation script
+# Run the Risc0 SDK installation script with secret mount
 # It will use the RISC0_VERSION, RISC0_CPP_VERSION and RISC0_RUST_VERSION defined above.
-RUN /tmp/install_risc0_sdk.sh && rm /tmp/install_risc0_sdk.sh
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+    /tmp/install_risc0_sdk.sh && rm /tmp/install_risc0_sdk.sh
 
 # Verify Risc0 installation (script also does this, but good for Dockerfile sanity)
 RUN echo "Verifying Risc0 installation in Dockerfile (post-script)..." && cargo risczero --version


### PR DESCRIPTION
Fixes #41

Injects GITHUB_TOKEN into the Risc0 Docker build via BuildKit secret mount (env=GITHUB_TOKEN). This prevents the rzup installer from hitting GitHub API rate limits in CI.