### PR TITLE
feat: update `detect_sdk_version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,6 +4019,7 @@ name = "ere-prover-airbender"
 version = "0.8.1"
 dependencies = [
  "airbender-host",
+ "bincode 2.0.1",
  "ere-compiler-airbender",
  "ere-compiler-core",
  "ere-prover-core",
@@ -4232,10 +4233,10 @@ dependencies = [
 name = "ere-verifier-airbender"
 version = "0.8.1"
 dependencies = [
- "airbender-host",
  "bincode 2.0.1",
  "ere-util-build",
  "ere-verifier-core",
+ "execution_utils",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/crates/catalog/build.rs
+++ b/crates/catalog/build.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::Path};
 
-use ere_util_build::{cargo_lock_path, detect_sdk_version, get_docker_image_tag, workspace};
+use ere_util_build::{cargo_lock_path, detect_dep_version, get_docker_image_tag, workspace};
 
 fn main() {
     generate_docker_image_tag();
@@ -36,13 +36,13 @@ fn generate_zkvm_sdk_version_impl() {
         sp1_version,
         zisk_version,
     ] = [
-        "airbender-sdk",
-        "openvm-sdk",
-        "risc0-zkvm",
-        "sp1-sdk",
-        "zisk-sdk",
+        ("ere-verifier-airbender", "execution_utils"),
+        ("ere-verifier-openvm", "openvm-sdk"),
+        ("ere-verifier-risc0", "risc0-zkvm"),
+        ("ere-verifier-sp1", "sp1-sdk"),
+        ("ere-verifier-zisk", "proofman-verifier"),
     ]
-    .map(detect_sdk_version);
+    .map(|(c, d)| detect_dep_version(c, d));
 
     let zkvm_sdk_version_impl = format!(
         r#"impl crate::zkVMKind {{

--- a/crates/prover/airbender/Cargo.toml
+++ b/crates/prover/airbender/Cargo.toml
@@ -25,6 +25,7 @@ ere-prover-core.workspace = true
 ere-verifier-airbender.workspace = true
 
 [dev-dependencies]
+bincode.workspace = true
 ere-compiler-airbender.workspace = true
 ere-util-test = { workspace = true, features = ["host"] }
 

--- a/crates/prover/airbender/src/prover.rs
+++ b/crates/prover/airbender/src/prover.rs
@@ -12,9 +12,7 @@ use airbender_execution_utils::{
     unified_circuit::compute_unified_setup_for_machine_configuration,
     verifier_binaries::{RECURSION_UNIFIED_BIN, RECURSION_UNIFIED_TXT},
 };
-use airbender_host::{
-    ExecutionResult, Runner, TranspilerRunner, TranspilerRunnerBuilder, UnifiedVk,
-};
+use airbender_host::{ExecutionResult, Runner, TranspilerRunner, TranspilerRunnerBuilder};
 #[cfg(feature = "cuda")]
 use airbender_host::{GpuProver, GpuProverBuilder, Proof, ProveResult, Prover as _};
 use airbender_riscv_transpiler::cycle::IWithoutByteAccessIsaConfigWithDelegation;
@@ -24,7 +22,7 @@ use ere_prover_core::{
     ProverResourceKind, PublicValues, zkVMProver,
 };
 use ere_verifier_airbender::{
-    AirbenderProgramVk, AirbenderProof, AirbenderVerifier, words_to_le_bytes,
+    AirbenderProgramVk, AirbenderProof, AirbenderVerifier, UnifiedVk, words_to_le_bytes,
 };
 use sha3::{Digest, Keccak256};
 use tempfile::tempdir;
@@ -350,19 +348,17 @@ mod tests {
     #[test]
     fn compute_program_vk_matches_sdk() {
         use ere_prover_core::codec::Encode;
-        use ere_verifier_airbender::AirbenderProgramVk;
 
         use crate::prover::{compute_program_vk, elf_to_bin};
 
         let elf = basic_elf();
         let (app_bin_hash, app_bin_path) = elf_to_bin(&elf).unwrap();
 
-        let program_vk =
-            AirbenderProgramVk(airbender_host::compute_unified_vk(&app_bin_path).unwrap());
+        let program_vk = airbender_host::compute_unified_vk(&app_bin_path).unwrap();
 
         assert_eq!(
             compute_program_vk(app_bin_hash).encode_to_vec().unwrap(),
-            program_vk.encode_to_vec().unwrap(),
+            bincode::serde::encode_to_vec(&program_vk, bincode::config::legacy()).unwrap(),
         );
     }
 }

--- a/crates/util/build/src/lib.rs
+++ b/crates/util/build/src/lib.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::{
+    collections::HashSet,
     env, fs,
     path::{Path, PathBuf},
 };
 
-use cargo_metadata::MetadataCommand;
+use cargo_metadata::{MetadataCommand, Source};
 
 /// Returns path to the closest workspace that contains `Cargo.lock` from `CARGO_MANIFEST_DIR`,
 /// returns `None` if not found.
@@ -28,28 +29,73 @@ pub fn cargo_lock_path() -> Option<PathBuf> {
     workspace().map(|workspace| workspace.join("Cargo.lock"))
 }
 
-// Detect and generate a Rust source file that contains the name and version of the SDK.
-pub fn detect_and_generate_name_and_sdk_version(name: &str, sdk_dep_name: &str) {
-    gen_name_and_sdk_version(name, &detect_sdk_version(sdk_dep_name));
+/// Detect the version of `dep_name` (direct dep of `crate_name`) and generate
+/// a Rust source file with the provided `name` and resolved version.
+pub fn detect_and_generate_name_and_sdk_version(name: &str, crate_name: &str, dep_name: &str) {
+    gen_name_and_sdk_version(name, &detect_dep_version(crate_name, dep_name));
 
     if let Some(cargo_lock) = cargo_lock_path() {
         println!("cargo:rerun-if-changed={}", cargo_lock.display());
     }
 }
 
-// Detect version of the SDK.
-pub fn detect_sdk_version(sdk_dep_name: &str) -> String {
+/// Resolves the version of `dep_name` as a direct dependency of `crate_name`.
+///
+/// Panics if `crate_name` is not in the workspace metadata, if `dep_name` is
+/// not a direct dependency of `crate_name`, or if more than one direct
+/// dependency named `dep_name` exists.
+pub fn detect_dep_version(crate_name: &str, dep_name: &str) -> String {
     let meta = MetadataCommand::new()
         .exec()
-        .expect("Failed to get cargo metadata");
+        .expect("cargo metadata should not fail");
 
-    meta.packages
+    let crate_pkg = meta
+        .packages
         .iter()
-        .find(|pkg| pkg.name.eq_ignore_ascii_case(sdk_dep_name))
-        .map(|pkg| pkg.version.to_string())
-        .unwrap_or_else(|| {
-            panic!("Dependency {sdk_dep_name} not found in Cargo.toml");
-        })
+        .find(|pkg| pkg.name.as_str() == crate_name)
+        .unwrap_or_else(|| panic!("package `{crate_name}` not found in workspace metadata"));
+    let crate_node = meta
+        .resolve
+        .as_ref()
+        .and_then(|resolve| resolve.nodes.iter().find(|node| node.id == crate_pkg.id))
+        .unwrap_or_else(|| panic!("resolve node for `{crate_name}` not found"));
+    let crate_deps: HashSet<_> = crate_node.deps.iter().map(|dep| &dep.pkg).collect();
+
+    let dep_pkgs = meta
+        .packages
+        .iter()
+        .filter(|pkg| pkg.name.as_str() == dep_name && crate_deps.contains(&pkg.id))
+        .collect::<Vec<_>>();
+    let dep_pkg = match dep_pkgs.as_slice() {
+        [dep_pkg] => *dep_pkg,
+        _ => panic!(
+            "expected exactly one dependency named `{dep_name}` in package `{crate_name}`, found {}",
+            dep_pkgs.len()
+        ),
+    };
+
+    resolve_pkg_version(dep_pkg.source.as_ref(), &dep_pkg.version.to_string())
+}
+
+/// Resolution based on the package's `source` and `version` in `Cargo.lock`:
+///
+/// | source                                                  | output       | example   |
+/// | ------------------------------------------------------- | ------------ | --------- |
+/// | `git+...?tag={tag}#{sha}`                               | `{tag}`      | `v1.4.3`  |
+/// | `git+...?...#{sha}` (non-tag deps)                      | `{sha:7}`    | `d15b86d` |
+/// | anything else (crates.io, path deps)                    | `v{version}` | `v3.0.5`  |
+pub fn resolve_pkg_version(source: Option<&Source>, version: &str) -> String {
+    if let Some(source) = source
+        && let Some(repr) = source.repr.strip_prefix("git+")
+        && let Some((repr, rev)) = repr.split_once('#')
+    {
+        return repr
+            .split_once("?tag=")
+            .map(|(_, tag)| tag.to_string())
+            .unwrap_or_else(|| rev[..7].to_string());
+    }
+
+    format!("v{version}")
 }
 
 // Generate a Rust source file that contains the provided name and version of the SDK.
@@ -94,4 +140,48 @@ pub fn get_docker_image_tag() -> String {
         .expect("crate to have version")
         .version
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use cargo_metadata::Source;
+
+    use crate::resolve_pkg_version;
+
+    #[test]
+    fn test_parse_sdk_version() {
+        for (repr, version, expected) in [
+            (
+                "registry+https://github.com/rust-lang/crates.io-index".into(),
+                "3.0.5",
+                "v3.0.5",
+            ),
+            (
+                "registry+https://github.com/rust-lang/crates.io-index".into(),
+                "6.1.0",
+                "v6.1.0",
+            ),
+            (
+                "git+https://github.com/openvm-org/openvm.git?tag=v1.4.3#e8feb93717200e6f334b4f368dd2d0a143f69436".into(),
+                "x.x.x",
+                "v1.4.3",
+            ),
+            (
+                "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547".into(),
+                "x.x.x",
+                "v0.16.1",
+            ),
+            (
+                "git+https://github.com/matter-labs//zksync-airbender?rev=d15b86db8a1683b5a641cb420fe6b009e1eb5acb#d15b86db8a1683b5a641cb420fe6b009e1eb5acb".into(),
+                "x.x.x",
+                "d15b86d",
+            ),
+            (None, "0.1.0", "v0.1.0"),
+        ] {
+            let source = repr.map(|repr| Source {
+                repr: repr.to_string(),
+            });
+            assert_eq!(resolve_pkg_version(source.as_ref(), version), expected);
+        }
+    }
 }

--- a/crates/verifier/airbender/Cargo.toml
+++ b/crates/verifier/airbender/Cargo.toml
@@ -11,7 +11,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 
 # Airbender dependencies
-airbender-host.workspace = true
+airbender-execution-utils.workspace = true
 
 # Local dependencies
 ere-verifier-core.workspace = true

--- a/crates/verifier/airbender/build.rs
+++ b/crates/verifier/airbender/build.rs
@@ -1,5 +1,9 @@
 use ere_util_build::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("airbender", "airbender-sdk");
+    detect_and_generate_name_and_sdk_version(
+        "airbender",
+        "ere-verifier-airbender",
+        "execution_utils",
+    );
 }

--- a/crates/verifier/airbender/src/error.rs
+++ b/crates/verifier/airbender/src/error.rs
@@ -1,4 +1,3 @@
-use airbender_host::HostError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -7,7 +6,7 @@ pub enum Error {
     #[error("Failed to deserialize: {0}")]
     Deserialize(#[from] bincode::error::DecodeError),
 
-    /// Error returned by the `airbender-host` SDK.
-    #[error(transparent)]
-    Sdk(#[from] HostError),
+    /// `verify_proof_in_unified_layer` returned `Err`.
+    #[error("Invalid proof")]
+    InvalidProof,
 }

--- a/crates/verifier/airbender/src/lib.rs
+++ b/crates/verifier/airbender/src/lib.rs
@@ -7,7 +7,7 @@ pub use ere_verifier_core::*;
 
 pub use crate::{
     error::Error,
-    program_vk::AirbenderProgramVk,
+    program_vk::{AirbenderProgramVk, UnifiedVk},
     proof::{AirbenderProof, words_to_le_bytes},
     verifier::AirbenderVerifier,
 };

--- a/crates/verifier/airbender/src/program_vk.rs
+++ b/crates/verifier/airbender/src/program_vk.rs
@@ -1,6 +1,16 @@
-use airbender_host::UnifiedVk;
+use airbender_execution_utils::{setups::CompiledCircuitsSet, unrolled::UnrolledProgramSetup};
 use ere_verifier_core::codec::impl_codec_by_bincode_legacy;
 use serde::{Deserialize, Serialize};
+
+/// Unified verification key bundle for recursion.
+///
+/// Vendored from `airbender_host::vk::UnifiedVk`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UnifiedVk {
+    pub app_bin_hash: [u8; 32],
+    pub unified_setup: UnrolledProgramSetup,
+    pub unified_layouts: CompiledCircuitsSet,
+}
 
 /// Verifying key that identifies a specific compiled guest program.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/verifier/airbender/src/proof.rs
+++ b/crates/verifier/airbender/src/proof.rs
@@ -1,6 +1,6 @@
 use core::array::from_fn;
 
-use airbender_host::raw::UnrolledProgramProof;
+use airbender_execution_utils::unrolled::UnrolledProgramProof;
 use serde::{Deserialize, Serialize};
 
 /// A proof produced by the host prover that bundles everything needed for

--- a/crates/verifier/airbender/src/verifier.rs
+++ b/crates/verifier/airbender/src/verifier.rs
@@ -1,4 +1,4 @@
-use airbender_host::verify_proof;
+use airbender_execution_utils::unified_circuit::verify_proof_in_unified_layer;
 use ere_verifier_core::{PublicValues, zkVMVerifier};
 
 use crate::{AirbenderProgramVk, AirbenderProof, Error};
@@ -31,7 +31,10 @@ impl zkVMVerifier for AirbenderVerifier {
     }
 
     fn verify(&self, proof: &AirbenderProof) -> Result<PublicValues, Error> {
-        verify_proof(&proof.0, &self.program_vk.0, None, None)?;
+        let setup = &self.program_vk.0.unified_setup;
+        let layouts = &self.program_vk.0.unified_layouts;
+        verify_proof_in_unified_layer(&proof.0, setup, layouts, false)
+            .map_err(|_| Error::InvalidProof)?;
 
         Ok(proof.public_values().into())
     }

--- a/crates/verifier/openvm/build.rs
+++ b/crates/verifier/openvm/build.rs
@@ -1,5 +1,5 @@
 use ere_util_build::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("openvm", "openvm-sdk");
+    detect_and_generate_name_and_sdk_version("openvm", "ere-verifier-openvm", "openvm-sdk");
 }

--- a/crates/verifier/risc0/build.rs
+++ b/crates/verifier/risc0/build.rs
@@ -1,5 +1,5 @@
 use ere_util_build::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("risc0", "risc0-zkvm");
+    detect_and_generate_name_and_sdk_version("risc0", "ere-verifier-risc0", "risc0-zkvm");
 }

--- a/crates/verifier/sp1/build.rs
+++ b/crates/verifier/sp1/build.rs
@@ -1,5 +1,5 @@
 use ere_util_build::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("sp1", "sp1-sdk");
+    detect_and_generate_name_and_sdk_version("sp1", "ere-verifier-sp1", "sp1-sdk");
 }

--- a/crates/verifier/zisk/build.rs
+++ b/crates/verifier/zisk/build.rs
@@ -1,5 +1,5 @@
 use ere_util_build::detect_and_generate_name_and_sdk_version;
 
 fn main() {
-    detect_and_generate_name_and_sdk_version("zisk", "zisk-sdk");
+    detect_and_generate_name_and_sdk_version("zisk", "ere-verifier-zisk", "proofman-verifier");
 }


### PR DESCRIPTION
- Update `ere-verifier-airbender` to use `airbender-execution-utils` directly for version resolution
- Update the `detect_sdk_version` to output in the following rules:
  
  | source                                                  | output       | example   |
  | ------------------------------------------------------- | ------------ | --------- |
  | `git+...?tag={tag}#{sha}`                               | `{tag}`      | `v1.4.3`  |
  | `git+...?...#{sha}` (non-tag deps)                      | `{sha:7}`    | `d15b86d` |
  | anything else (crates.io, path deps)                    | `v{version}` | `v3.0.5`  |
  
  Now the zkVM SDK versions (with `v` prefix to semver, show git sha 7 chars if it's non-tag git dep):
  
  ```rust
  impl crate::zkVMKind {
      pub fn sdk_version(&self) -> &'static str {
          match self {
              Self::Airbender => "d15b86d",
              Self::OpenVM => "v1.4.3",
              Self::Risc0 => "v3.0.5",
              Self::SP1 => "v6.1.0",
              Self::Zisk => "v0.16.1",
          }
      }
  }
  ```
  
  Previously
  
  ```rust
  impl crate::zkVMKind {
      pub fn sdk_version(&self) -> &'static str {
          match self {
              Self::Airbender => "0.1.0",
              Self::OpenVM => "1.4.3",
              Self::Risc0 => "3.0.5",
              Self::SP1 => "6.1.0",
              Self::Zisk => "0.16.1",
          }
      }
  }
  ```
  
  I'm planning to use this for the `ere-guests` EL as well, so eventually we can output something like `ethrex-33695e2/zisk-v0.16.1` using the same function