### PR TITLE
feat(provers): Add optional cycle tracking to proving report

### DIFF
--- a/crates/prover/airbender/src/prover.rs
+++ b/crates/prover/airbender/src/prover.rs
@@ -149,13 +149,13 @@ impl zkVMProver for AirbenderProver {
             .map_err(|err| Error::ExecutePanic(panic_msg(err)))??;
 
         let start = Instant::now();
-        let (proof, receipt) = match gpu_prover.prove(&input_words)? {
+        let (proof, receipt, cycles) = match gpu_prover.prove(&input_words)? {
             ProveResult {
                 proof: Proof::Real(proof),
                 receipt,
-                ..
+                cycles,
             } if proof.level() == airbender_host::ProverLevel::RecursionUnified => {
-                (proof.into_inner(), receipt)
+                (proof.into_inner(), receipt, cycles)
             }
             _ => Err(Error::Sdk(airbender_host::HostError::Prover(
                 "Expected Proof::Real in ProverLevel::RecursionUnified".to_string(),
@@ -166,7 +166,10 @@ impl zkVMProver for AirbenderProver {
         Ok((
             words_to_le_bytes(receipt.output).into(),
             AirbenderProof(proof),
-            ProgramProvingReport::new(proving_time),
+            ProgramProvingReport {
+                proving_time,
+                total_num_cycles: Some(cycles),
+            },
         ))
     }
 }

--- a/crates/prover/core/src/report.rs
+++ b/crates/prover/core/src/report.rs
@@ -30,12 +30,19 @@ impl ProgramExecutionReport {
 
 /// ProgramProvingReport produces information about proving a particular
 /// program's instance.
+///
+/// Note: Execution is fused into the proving pipeline.
+/// To get separate execution metrics, call `execute()` before `prove()`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProgramProvingReport {
     pub proving_time: Duration,
+    pub total_num_cycles: Option<u64>,
 }
 impl ProgramProvingReport {
     pub fn new(proving_time: Duration) -> Self {
-        Self { proving_time }
+        Self {
+            proving_time,
+            total_num_cycles: None,
+        }
     }
 }

--- a/crates/prover/risc0/src/prover.rs
+++ b/crates/prover/risc0/src/prover.rs
@@ -163,7 +163,10 @@ impl zkVMProver for Risc0Prover {
         Ok((
             public_values,
             proof,
-            ProgramProvingReport::new(proving_time),
+            ProgramProvingReport {
+                proving_time,
+                total_num_cycles: Some(prove_info.stats.total_cycles),
+            },
         ))
     }
 }


### PR DESCRIPTION
Resolves part of #28.

Updates `ProgramProvingReport` to track cycle counts during proving mode. `execution_duration` was omitted because no current zkVM SDK cleanly separates or exposes internal execution time during a `prove()` call (due to fused/black-box trace generation pipelines).

**Changes:**

* **`core`**: Added `total_num_cycles: Option<u64>` to `ProgramProvingReport`.
* **`risc0`**: Populated cycles via the exposed `prove_info.stats.total_cycles`.
* **`airbender`**: Extracts cycles directly from the GPU prover's `ProveResult`. (The interpreter's pre-flight pass is not timed to emulate execution_duration. Execution is fused into the proving pipeline, making pre-flight timing an inaccurate reflection of actual proving-phase execution.
* **`sp1` / `openvm` / `zisk`**: Default to `None`. Their respective SDKs drop or hide execution metrics during proving, returning only the final proof artifacts. (To get cycles for these, `execute()` must be call prior to `prove()`).