### PR TITLE
feat: add --ignore-rust-version support

### DIFF
--- a/crates/cluster-client/zisk/src/client.rs
+++ b/crates/cluster-client/zisk/src/client.rs
@@ -311,10 +311,10 @@ fn parse_proof(bytes: &[u8]) -> Result<ZiskProof, Error> {
     };
 
     let public_values = {
-        let to_u64 = |bytes: &[u8]| u32::from_le_bytes(bytes.try_into().unwrap()) as u64;
+        let to_u64 = |bytes: &[u8; 4]| u32::from_le_bytes(*bytes) as u64;
         iter::empty()
             .chain(proof.program_vk.vk)
-            .chain(proof.publics.data.chunks_exact(4).map(to_u64))
+            .chain(proof.publics.data.as_chunks::<4>().0.iter().map(to_u64))
             .collect()
     };
 

--- a/crates/compiler/openvm/src/rust_rv32ima.rs
+++ b/crates/compiler/openvm/src/rust_rv32ima.rs
@@ -1,7 +1,7 @@
 use std::{env, path::Path};
 
 use ere_compiler_core::{Compiler, Elf};
-use ere_util_compile::{CargoBuildCmd, parse_cargo_features};
+use ere_util_compile::{CargoBuildCmd, parse_cargo_build_options};
 
 use crate::Error;
 
@@ -45,11 +45,13 @@ impl Compiler for OpenVMRustRv32ima {
         args: &[String],
     ) -> Result<Elf, Self::Error> {
         let toolchain = env::var("ERE_RUST_TOOLCHAIN").unwrap_or_else(|_| "nightly".into());
+        let options = parse_cargo_build_options(args)?;
         let elf = CargoBuildCmd::new()
             .toolchain(toolchain)
             .build_options(CARGO_BUILD_OPTIONS)
             .rustflags(RUSTFLAGS)
-            .features(&parse_cargo_features(args)?)
+            .features(&options.features)
+            .ignore_rust_version(options.ignore_rust_version)
             .exec(guest_directory, TARGET_TRIPLE)?;
         Ok(Elf(elf))
     }

--- a/crates/compiler/openvm/src/rust_rv32ima_customized.rs
+++ b/crates/compiler/openvm/src/rust_rv32ima_customized.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path};
 
 use ere_compiler_core::{Compiler, Elf};
-use ere_util_compile::{CommonError, parse_cargo_features, rustup_add_rust_src};
+use ere_util_compile::{CommonError, parse_cargo_build_options, rustup_add_rust_src};
 use openvm_build::{GuestOptions, get_rustup_toolchain_name};
 
 use crate::Error;
@@ -25,10 +25,16 @@ impl Compiler for OpenVMRustRv32imaCustomized {
         // Inlining `openvm_sdk::Sdk::build` in order to get raw elf bytes.
         let guest_directory = guest_directory.as_ref();
         let pkg = openvm_build::get_package(guest_directory);
+        let options = parse_cargo_build_options(args)?;
         let guest_opts = GuestOptions::default()
             .with_rustc_flags(extra_rustflags.split_whitespace().map(String::from))
             .with_profile("release".to_string())
-            .with_features(parse_cargo_features(args)?);
+            .with_features(options.features)
+            .with_options(
+                options
+                    .ignore_rust_version
+                    .then_some("--ignore-rust-version"),
+            );
         let target_dir = match openvm_build::build_guest_package(&pkg, &guest_opts, None, &None) {
             Ok(target_dir) => target_dir,
             Err(Some(code)) => return Err(Error::BuildFailed(code))?,

--- a/crates/compiler/sp1/src/rust_rv64ima.rs
+++ b/crates/compiler/sp1/src/rust_rv64ima.rs
@@ -1,7 +1,7 @@
 use std::{env, path::Path};
 
 use ere_compiler_core::{Compiler, Elf};
-use ere_util_compile::{CargoBuildCmd, RustTarget, parse_cargo_features};
+use ere_util_compile::{CargoBuildCmd, RustTarget, parse_cargo_build_options};
 
 use crate::Error;
 
@@ -55,11 +55,13 @@ impl Compiler for SP1RustRv64ima {
         args: &[String],
     ) -> Result<Elf, Self::Error> {
         let toolchain = env::var("ERE_RUST_TOOLCHAIN").unwrap_or_else(|_| "nightly".into());
+        let options = parse_cargo_build_options(args)?;
         let elf = CargoBuildCmd::new()
             .toolchain(toolchain)
             .build_options(CARGO_BUILD_OPTIONS)
             .rustflags(RUSTFLAGS)
-            .features(&parse_cargo_features(args)?)
+            .features(&options.features)
+            .ignore_rust_version(options.ignore_rust_version)
             .exec(guest_directory, TARGET)?;
         Ok(Elf(elf))
     }

--- a/crates/compiler/sp1/src/rust_rv64ima_customized.rs
+++ b/crates/compiler/sp1/src/rust_rv64ima_customized.rs
@@ -53,7 +53,7 @@ impl Compiler for SP1RustRv64imaCustomized {
             .map_err(|err| CommonError::command(&cmd, err))?;
 
         if !status.success() {
-            return Err(CommonError::command_exit_non_zero(&cmd, status, None))?;
+            Err(CommonError::command_exit_non_zero(&cmd, status, None))?;
         }
 
         let elf_path = output_dir.path().join("guest.elf");

--- a/crates/compiler/sp1/src/rust_rv64ima_customized.rs
+++ b/crates/compiler/sp1/src/rust_rv64ima_customized.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path, process::Command};
 
 use ere_compiler_core::{Compiler, Elf};
-use ere_util_compile::{CommonError, cargo_metadata, parse_cargo_features};
+use ere_util_compile::{CommonError, cargo_metadata, parse_cargo_build_options};
 use tempfile::tempdir;
 use tracing::info;
 
@@ -41,9 +41,12 @@ impl Compiler for SP1RustRv64imaCustomized {
             "--elf-name",
             "guest.elf",
         ]);
-        let features = parse_cargo_features(args)?;
-        if !features.is_empty() {
-            cmd.args(["--features", &features.join(",")]);
+        let options = parse_cargo_build_options(args)?;
+        if !options.features.is_empty() {
+            cmd.args(["--features", &options.features.join(",")]);
+        }
+        if options.ignore_rust_version {
+            cmd.arg("--ignore-rust-version");
         }
         let status = cmd
             .status()

--- a/crates/compiler/zisk/src/rust_rv64ima.rs
+++ b/crates/compiler/zisk/src/rust_rv64ima.rs
@@ -1,7 +1,7 @@
 use std::{env, path::Path};
 
 use ere_compiler_core::{Compiler, Elf};
-use ere_util_compile::{CargoBuildCmd, RustTarget, parse_cargo_features};
+use ere_util_compile::{CargoBuildCmd, RustTarget, parse_cargo_build_options};
 
 use crate::Error;
 
@@ -51,12 +51,14 @@ impl Compiler for ZiskRustRv64ima {
         args: &[String],
     ) -> Result<Elf, Self::Error> {
         let toolchain = env::var("ERE_RUST_TOOLCHAIN").unwrap_or_else(|_| "nightly".into());
+        let options = parse_cargo_build_options(args)?;
         let elf = CargoBuildCmd::new()
             .linker_script(Some(LINKER_SCRIPT))
             .toolchain(toolchain)
             .build_options(CARGO_BUILD_OPTIONS)
             .rustflags(RUSTFLAGS)
-            .features(&parse_cargo_features(args)?)
+            .features(&options.features)
+            .ignore_rust_version(options.ignore_rust_version)
             .exec(guest_directory, TARGET)?;
         Ok(Elf(elf))
     }

--- a/crates/compiler/zisk/src/rust_rv64ima_customized.rs
+++ b/crates/compiler/zisk/src/rust_rv64ima_customized.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use ere_compiler_core::{Compiler, Elf};
-use ere_util_compile::{CargoBuildCmd, parse_cargo_features};
+use ere_util_compile::{CargoBuildCmd, parse_cargo_build_options};
 
 use crate::Error;
 
@@ -80,10 +80,12 @@ impl Compiler for ZiskRustRv64imaCustomized {
         args: &[String],
     ) -> Result<Elf, Self::Error> {
         let flags: Vec<&str> = [profile_flags(), RUSTFLAGS].concat();
+        let options = parse_cargo_build_options(args)?;
         let elf = CargoBuildCmd::new()
             .toolchain(ZISK_TOOLCHAIN)
             .rustflags(&flags)
-            .features(&parse_cargo_features(args)?)
+            .features(&options.features)
+            .ignore_rust_version(options.ignore_rust_version)
             .exec(guest_directory, ZISK_TARGET)?;
         Ok(Elf(elf))
     }

--- a/crates/dockerized/src/util/docker.rs
+++ b/crates/dockerized/src/util/docker.rs
@@ -27,7 +27,7 @@ impl CmdOption {
     pub fn to_args(&self) -> Vec<String> {
         let Self(key, value) = self;
         match value {
-            Some(value) => vec![format!("--{key}"), format!("{value}")],
+            Some(value) => vec![format!("--{key}"), value.to_string()],
             None => vec![format!("--{key}")],
         }
     }

--- a/crates/util/compile/src/lib.rs
+++ b/crates/util/compile/src/lib.rs
@@ -6,7 +6,8 @@ mod rust;
 pub use crate::{
     error::CommonError,
     rust::{
-        CargoBuildCmd, RustTarget, cargo_metadata, parse_cargo_features, rustc_path,
-        rustup_active_toolchain, rustup_add_components, rustup_add_rust_src, rustup_add_target,
+        CargoBuildCmd, CargoBuildOptions, RustTarget, cargo_metadata, parse_cargo_build_options,
+        rustc_path, rustup_active_toolchain, rustup_add_components, rustup_add_rust_src,
+        rustup_add_target,
     },
 };

--- a/crates/util/compile/src/rust.rs
+++ b/crates/util/compile/src/rust.rs
@@ -53,6 +53,7 @@ pub struct CargoBuildCmd {
     build_options: Vec<String>,
     linker_script: Option<String>,
     features: Vec<String>,
+    ignore_rust_version: bool,
 }
 
 impl Default for CargoBuildCmd {
@@ -64,6 +65,7 @@ impl Default for CargoBuildCmd {
             build_options: Default::default(),
             linker_script: Default::default(),
             features: Default::default(),
+            ignore_rust_version: Default::default(),
         }
     }
 }
@@ -112,6 +114,12 @@ impl CargoBuildCmd {
     /// Cargo features to enable.
     pub fn features(mut self, features: &[impl AsRef<str>]) -> Self {
         self.features = features.iter().map(|v| v.as_ref().to_string()).collect();
+        self
+    }
+
+    /// Whether to ignore `rust-version` specification in packages.
+    pub fn ignore_rust_version(mut self, ignore_rust_version: bool) -> Self {
+        self.ignore_rust_version = ignore_rust_version;
         self
     }
 
@@ -176,6 +184,10 @@ impl CargoBuildCmd {
             .into_iter()
             .flatten();
 
+        let ignore_rust_version_arg = self
+            .ignore_rust_version
+            .then(|| "--ignore-rust-version".to_string());
+
         let args = iter::empty()
             .chain([plus_toolchain(&self.toolchain)])
             .chain(["build".into()])
@@ -183,7 +195,8 @@ impl CargoBuildCmd {
             .chain(["--profile".into(), self.profile.clone()])
             .chain(["--target".into(), target_arg])
             .chain(["--manifest-path".into(), package.manifest_path.to_string()])
-            .chain(features_args);
+            .chain(features_args)
+            .chain(ignore_rust_version_arg);
 
         let mut cmd = Command::new("cargo");
         let status = cmd
@@ -330,16 +343,61 @@ fn plus_toolchain(toolchain: &str) -> String {
     format!("+{toolchain}")
 }
 
-/// Parse cargo-style `--features` / `-F` flags out of `args`.
-pub fn parse_cargo_features(args: &[String]) -> Result<Vec<String>, CommonError> {
+/// Cargo build options parsed out of the extra arguments given to a compiler.
+#[derive(Clone, Debug, Default)]
+pub struct CargoBuildOptions {
+    /// Cargo features to enable.
+    pub features: Vec<String>,
+    /// Whether to ignore `rust-version` specification in packages.
+    pub ignore_rust_version: bool,
+}
+
+/// Parse cargo-style build flags out of `args`.
+pub fn parse_cargo_build_options(args: &[String]) -> Result<CargoBuildOptions, CommonError> {
     #[derive(Parser, Debug)]
     #[command(no_binary_name = true)]
     struct Args {
         #[arg(short = 'F', long = "features", value_delimiter = ',')]
         features: Vec<String>,
+        #[arg(long)]
+        ignore_rust_version: bool,
     }
 
     Args::try_parse_from(args)
-        .map(|p| p.features)
+        .map(|p| CargoBuildOptions {
+            features: p.features,
+            ignore_rust_version: p.ignore_rust_version,
+        })
         .map_err(CommonError::invalid_args)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rust::parse_cargo_build_options;
+
+    fn parse(args: &[&str]) -> (Vec<String>, bool) {
+        let args = args.iter().map(ToString::to_string).collect::<Vec<_>>();
+        let options = parse_cargo_build_options(&args).unwrap();
+        (options.features, options.ignore_rust_version)
+    }
+
+    #[test]
+    fn test_parse_cargo_build_options() {
+        assert_eq!(parse(&[]), (vec![], false));
+        assert_eq!(parse(&["--ignore-rust-version"]), (vec![], true));
+        assert_eq!(
+            parse(&["--features", "a,b"]),
+            (vec!["a".into(), "b".into()], false)
+        );
+        assert_eq!(
+            parse(&["-F", "a", "--ignore-rust-version"]),
+            (vec!["a".into()], true)
+        );
+    }
+
+    #[test]
+    fn test_parse_cargo_build_options_rejects_unknown() {
+        let args = ["--unknown".to_string()];
+        assert!(parse_cargo_build_options(&args).is_err());
+    }
 }


### PR DESCRIPTION
To be able to compile some guest with MSRV larger than customized Rust toolchain version (the MSRV might be required for other features the guest doesn't enable).