### PR TITLE
feat: update sp1 to v6.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,6 +2647,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "group 0.13.0",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.1",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,7 +3613,7 @@ dependencies = [
  "sp1-cuda",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "sp1-sdk",
  "sysinfo 0.35.2",
@@ -3778,7 +3805,7 @@ dependencies = [
  "ere-verifier-core",
  "serde",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-verifier",
  "thiserror 2.0.18",
 ]
@@ -3918,6 +3945,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -5190,8 +5223,8 @@ dependencies = [
 
 [[package]]
 name = "libzkevm"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/sp1-patches/bls12_381?tag=patch-0.8.0-sp1-6.2.0)",
  "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-6.2.0)",
@@ -10260,8 +10293,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-air 0.4.3-succinct",
 ]
@@ -10279,8 +10312,8 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.4.3-succinct",
@@ -10289,45 +10322,45 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "lazy_static",
  "p3-baby-bear 0.4.3-succinct",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-basefold"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-primitives 6.4.0",
+ "slop-primitives 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -10335,24 +10368,24 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "rand 0.8.6",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-fri",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-tensor",
@@ -10376,16 +10409,16 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -10403,20 +10436,20 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "futures",
  "p3-challenger 0.4.3-succinct",
  "serde",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-commit"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-commit",
  "serde",
@@ -10425,12 +10458,12 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-dft 0.4.3-succinct",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-matrix",
  "slop-tensor",
@@ -10438,16 +10471,16 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "crossbeam",
  "futures",
@@ -10460,8 +10493,8 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "futures",
@@ -10470,21 +10503,21 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -10493,8 +10526,8 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-keccak-air 0.4.3-succinct",
 ]
@@ -10516,54 +10549,54 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "slop-matrix"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-matrix 0.4.3-succinct",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-maybe-rayon 0.4.3-succinct",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
  "p3-merkle-tree",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
@@ -10571,8 +10604,8 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "futures",
@@ -10580,9 +10613,9 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-matrix",
@@ -10600,8 +10633,8 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-poseidon2 0.4.3-succinct",
 ]
@@ -10617,26 +10650,26 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "futures",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-merkle-tree",
@@ -10647,17 +10680,17 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "futures",
  "itertools 0.14.0",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-multilinear",
  "thiserror 1.0.69",
 ]
@@ -10673,16 +10706,16 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-symmetric 0.4.3-succinct",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -10690,7 +10723,7 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-futures",
  "slop-matrix",
@@ -10700,16 +10733,16 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-util 0.4.3-succinct",
  "tracing-forest",
@@ -10718,8 +10751,8 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "derive-where",
  "futures",
@@ -10727,15 +10760,15 @@ dependencies = [
  "rand 0.8.6",
  "rayon",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-baby-bear",
  "slop-basefold",
- "slop-challenger 6.4.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-dft",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
@@ -10796,21 +10829,21 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
  "chrono",
  "clap",
  "dirs 5.0.1",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "bytemuck",
@@ -10831,13 +10864,13 @@ dependencies = [
  "serde_arrays 0.2.0",
  "serde_json",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-maybe-rayon",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "strum 0.27.2",
  "subenum",
  "thiserror 1.0.69",
@@ -10849,8 +10882,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "base64 0.22.1",
  "bincode 1.3.3",
@@ -10862,7 +10895,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-executor-runner-binary",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sysinfo 0.30.13",
  "tracing",
  "uuid",
@@ -10870,8 +10903,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "crash-handler",
@@ -10884,8 +10917,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "cfg-if",
@@ -10902,8 +10935,8 @@ dependencies = [
  "serde",
  "serde_json",
  "slop-air",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-keccak-air",
  "slop-matrix",
@@ -10916,7 +10949,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "static_assertions",
  "struct-reflection",
  "strum 0.27.2",
@@ -10932,8 +10965,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -10943,7 +10976,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "thiserror 1.0.69",
@@ -10953,28 +10986,30 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "cfg-if",
+ "curve25519-dalek",
  "dashu",
  "elliptic-curve",
  "generic-array 1.1.0",
+ "group 0.13.0",
  "itertools 0.14.0",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "snowbridge-amcl",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "typenum",
 ]
 
 [[package]]
 name = "sp1-derive"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10983,8 +11018,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -10999,28 +11034,28 @@ dependencies = [
  "rayon-scan",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-futures",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
- "slop-poseidon2 6.4.0",
+ "slop-poseidon2 6.5.0",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "struct-reflection",
  "strum 0.27.2",
  "thiserror 1.0.69",
@@ -11031,8 +11066,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -11040,7 +11075,7 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tracing",
  "uuid",
 ]
@@ -11059,12 +11094,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "serde",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
@@ -11093,8 +11128,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "blake3",
@@ -11105,19 +11140,19 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "sp1-prover"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -11144,22 +11179,22 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-futures",
  "slop-jagged",
  "slop-multilinear",
  "slop-stacked",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
@@ -11180,8 +11215,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -11194,7 +11229,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "tokio",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
@@ -11203,8 +11238,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "itertools 0.14.0",
@@ -11212,28 +11247,28 @@ dependencies = [
  "rayon",
  "serde",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-alloc",
  "slop-basefold",
  "slop-basefold-prover",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
  "slop-commit",
  "slop-jagged",
- "slop-koala-bear 6.4.0",
+ "slop-koala-bear 6.5.0",
  "slop-matrix",
  "slop-merkle-tree",
  "slop-multilinear",
  "slop-stacked",
  "slop-sumcheck",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "slop-tensor",
  "slop-whir",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
@@ -11242,19 +11277,19 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "backtrace",
  "cfg-if",
  "itertools 0.14.0",
  "serde",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -11262,8 +11297,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -11271,10 +11306,10 @@ dependencies = [
  "itertools 0.14.0",
  "range-set-blaze",
  "serde",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-maybe-rayon",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
  "smallvec",
  "sp1-derive",
  "sp1-hypercube",
@@ -11285,8 +11320,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -11296,10 +11331,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-compiler",
  "sp1-verifier",
  "tempfile",
@@ -11308,20 +11343,20 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
  "slop-air",
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
  "slop-basefold",
  "slop-matrix",
  "slop-maybe-rayon",
- "slop-symmetric 6.4.0",
+ "slop-symmetric 6.5.0",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "strum 0.27.2",
  "tracing",
@@ -11329,8 +11364,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -11363,7 +11398,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-cuda",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
@@ -11380,8 +11415,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "blake3",
@@ -11391,12 +11426,12 @@ dependencies = [
  "lazy_static",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
  "sp1-hypercube",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum 0.27.2",
@@ -11406,8 +11441,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -11419,9 +11454,9 @@ dependencies = [
  "libm",
  "rand 0.8.6",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "sp1-lib 6.4.0",
- "sp1-primitives 6.4.0",
+ "slop-algebra 6.5.0",
+ "sp1-lib 6.5.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,16 +144,16 @@ openvm-transpiler = { git = "https://github.com/han0110/openvm.git", branch = "p
 openvm-verify-stark-host = { git = "https://github.com/han0110/openvm.git", branch = "patch/v2.1.0-preview", default-features = false }
 
 # SP1 dependencies
-sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-cuda = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-jit = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-primitives = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-verifier = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0" }
-sp1-zkvm = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0", default-features = false }
-sp1-libzkevm = { git = "https://github.com/succinctlabs/sp1", tag = "v6.4.0", package = "libzkevm" }
+sp1-core-executor = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-cuda = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-hypercube = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-jit = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-primitives = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-recursion-executor = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-verifier = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0" }
+sp1-zkvm = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0", default-features = false }
+sp1-libzkevm = { git = "https://github.com/succinctlabs/sp1", tag = "v6.5.0", package = "libzkevm" }
 
 # ZisK dependencies
 proofman-fields = "1.2.0-alpha"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Different zkVMs handles public values in different approaches:
 | zkVM   | Version                                                                    | ISA       |  GPU  | Multi GPU | Cluster |
 | ------ | -------------------------------------------------------------------------- | --------- | :---: | :-------: | :-----: |
 | OpenVM | [`2.1.0-preview`](https://github.com/openvm-org/openvm/tree/v2.1.0-preview) | `RV64IMA` |   V   |           |         |
-| SP1    | [`6.4.0`](https://github.com/succinctlabs/sp1/tree/v6.4.0)                 | `RV64IMA` |   V   |           |         |
+| SP1    | [`6.5.0`](https://github.com/succinctlabs/sp1/tree/v6.5.0)                 | `RV64IMA` |   V   |           |         |
 | ZisK   | [`1.2.0-alpha`](https://github.com/0xPolygonHermez/zisk/tree/v1.2.0-alpha) | `RV64IMA` |   V   |     V     |    V    |
 
 ## Examples

--- a/crates/compiler/sp1/src/rust_rv64ima.rs
+++ b/crates/compiler/sp1/src/rust_rv64ima.rs
@@ -19,7 +19,7 @@ const TARGET: RustTarget = RustTarget::SpecJson {
     json: include_str!("./rust_rv64ima/riscv64ima-unknown-none-elf.json"),
 };
 
-/// According to https://github.com/succinctlabs/sp1/blob/v6.4.0/crates/build/src/command/utils.rs#L68.
+/// According to https://github.com/succinctlabs/sp1/blob/v6.5.0/crates/build/src/command/utils.rs#L68.
 const RUSTFLAGS: &[&str] = &[
     "-C",
     "passes=lower-atomic", // Only for rustc > 1.81

--- a/docker/sp1/Dockerfile.base
+++ b/docker/sp1/Dockerfile.base
@@ -20,7 +20,7 @@ COPY --chmod=755 scripts/sdk_installers/install_sp1_sdk.sh /tmp/install_sp1_sdk.
 # Define where SP1 SDK will be installed within the image.
 # The install_sp1_sdk.sh script will respect these ENV variables.
 ENV SP1_DIR="/root/.sp1" \
-    SP1_VERSION="v6.4.0"
+    SP1_VERSION="v6.5.0"
 
 # Run the SP1 SDK installation script with secret mount
 # It will use the SP1_DIR and SP1_VERSION defined above.

--- a/docs/vk-generation.md
+++ b/docs/vk-generation.md
@@ -88,7 +88,7 @@ This guide records the encoding for each supported zkVM and gives the commands t
 
 ### Format
 
-32-bytes holding the 8 koalabear field elements of the digest packed as base-2^31 digits of a big-endian integer, which is the form [`HashableKey::bytes32`](https://github.com/succinctlabs/sp1/blob/v6.4.0/crates/hypercube/src/verifier/hashable_key.rs) prints and what `cargo prove vkey` reports.
+32-bytes holding the 8 koalabear field elements of the digest packed as base-2^31 digits of a big-endian integer, which is the form [`HashableKey::bytes32`](https://github.com/succinctlabs/sp1/blob/v6.5.0/crates/hypercube/src/verifier/hashable_key.rs) prints and what `cargo prove vkey` reports.
 
 ### Instructions
 
@@ -100,7 +100,7 @@ This guide records the encoding for each supported zkVM and gives the commands t
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     . "$HOME/.cargo/env"
 
-    ZKVM_VERSION="v6.4.0"
+    ZKVM_VERSION="v6.5.0"
     curl -L https://sp1up.succinct.xyz | bash
     export PATH="$HOME/.sp1/bin:$PATH"
     sp1up -v "$ZKVM_VERSION"

--- a/scripts/sdk_installers/install_sp1_sdk.sh
+++ b/scripts/sdk_installers/install_sp1_sdk.sh
@@ -27,7 +27,7 @@ curl -L https://sp1up.succinct.xyz | bash
 # and for subsequent commands if this script is sourced.
 export PATH="${SP1_DIR}/bin:$PATH"
 
-export SP1_VERSION="${SP1_VERSION:-v6.4.0}"
+export SP1_VERSION="${SP1_VERSION:-v6.5.0}"
 
 # Run sp1up to install/update the toolchain
 if ! command -v sp1up &> /dev/null; then

--- a/tests/sp1/basic/Cargo.lock
+++ b/tests/sp1/basic/Cargo.lock
@@ -388,15 +388,15 @@ dependencies = [
 
 [[package]]
 name = "ere-codec"
-version = "0.16.3"
+version = "0.17.0"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.16.3"
+version = "0.17.0"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "ere-platform-core",
  "libzkevm",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "ere-util-test"
-version = "0.16.3"
+version = "0.17.0"
 dependencies = [
  "bincode 2.0.1",
  "ciborium",
@@ -724,8 +724,8 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libzkevm"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bls12_381",
  "k256",
@@ -1321,8 +1321,8 @@ dependencies = [
 
 [[package]]
 name = "slop-algebra"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1346,16 +1346,16 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "ff",
  "p3-bn254-fr",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -1373,14 +1373,14 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "futures",
  "p3-challenger",
  "serde",
- "slop-algebra 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -1400,16 +1400,16 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
  "serde",
- "slop-algebra 6.4.0",
- "slop-challenger 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
@@ -1423,8 +1423,8 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-poseidon2",
 ]
@@ -1440,10 +1440,10 @@ dependencies = [
 
 [[package]]
 name = "slop-primitives"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
- "slop-algebra 6.4.0",
+ "slop-algebra 6.5.0",
 ]
 
 [[package]]
@@ -1457,8 +1457,8 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "p3-symmetric",
 ]
@@ -1483,12 +1483,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "serde",
- "sp1-primitives 6.4.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]
@@ -1517,8 +1517,8 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "bincode 1.3.3",
  "blake3",
@@ -1529,19 +1529,19 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slop-algebra 6.4.0",
- "slop-bn254 6.4.0",
- "slop-challenger 6.4.0",
- "slop-koala-bear 6.4.0",
- "slop-poseidon2 6.4.0",
- "slop-primitives 6.4.0",
- "slop-symmetric 6.4.0",
+ "slop-algebra 6.5.0",
+ "slop-bn254 6.5.0",
+ "slop-challenger 6.5.0",
+ "slop-koala-bear 6.5.0",
+ "slop-poseidon2 6.5.0",
+ "slop-primitives 6.5.0",
+ "slop-symmetric 6.5.0",
 ]
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.4.0"
-source = "git+https://github.com/succinctlabs/sp1?tag=v6.4.0#f66b4bff51d0ccff51d152e0f7f66b2ffedf3529"
+version = "6.5.0"
+source = "git+https://github.com/succinctlabs/sp1?tag=v6.5.0#92b8eabaea9ab7306da5826caa700adabf7445ba"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1552,8 +1552,8 @@ dependencies = [
  "libm",
  "rand",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp1-lib 6.4.0",
- "sp1-primitives 6.4.0",
+ "sp1-lib 6.5.0",
+ "sp1-primitives 6.5.0",
 ]
 
 [[package]]

--- a/tests/sp1/stock_nightly_no_std/src/sp1.rs
+++ b/tests/sp1/stock_nightly_no_std/src/sp1.rs
@@ -32,13 +32,13 @@ _start:
     sym STACK_TOP
 );
 
-/// According to https://github.com/succinctlabs/sp1/blob/v6.4.0/crates/zkvm/entrypoint/src/syscalls/sys.rs#L56-L59.
+/// According to https://github.com/succinctlabs/sp1/blob/v6.5.0/crates/zkvm/entrypoint/src/syscalls/sys.rs#L56-L59.
 #[panic_handler]
 fn panic_impl(_panic_info: &core::panic::PanicInfo) -> ! {
     halt(1);
 }
 
-/// According to https://github.com/succinctlabs/sp1/blob/v6.4.0/crates/zkvm/entrypoint/src/syscalls/halt.rs#L59-L63.
+/// According to https://github.com/succinctlabs/sp1/blob/v6.5.0/crates/zkvm/entrypoint/src/syscalls/halt.rs#L59-L63.
 fn halt(exit_code: u32) -> ! {
     unsafe {
         core::arch::asm!(
@@ -66,7 +66,7 @@ unsafe impl GlobalAlloc for SimpleAlloc {
 #[global_allocator]
 static HEAP: SimpleAlloc = SimpleAlloc;
 
-// According to https://github.com/succinctlabs/sp1/blob/v6.4.0/crates/primitives/src/consts.rs#L8.
+// According to https://github.com/succinctlabs/sp1/blob/v6.5.0/crates/primitives/src/consts.rs#L8.
 pub const MAXIMUM_MEMORY_SIZE: u64 = (1u64 << 48) - 1;
 
 #[allow(clippy::missing_safety_doc)]


### PR DESCRIPTION
Update SP1 from `v6.4.0` to `v6.5.0` across the workspace dependencies, both lockfiles, Docker/SDK installer defaults, the supported-version table, and version-pinned source references.

The nested guest lockfile was refreshed minimally: only the ERE path-package versions and SP1 git packages changed. Historical changelog entries remain untouched.

Resolves #415.

## Verification

- `cargo check -p ere-platform-sp1`
- `cargo check -p ere-verifier-sp1 --locked`
- `cargo check --manifest-path tests/sp1/basic/Cargo.toml --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- verified all five pinned SP1 source links against tag `v6.5.0`